### PR TITLE
Initialize astrocat lobby package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,2 +1,63 @@
-# astrocatlobby
-astrocatlobby
+# Astrocat Lobby
+
+Astrocat Lobby is a tiny reference project that tracks a roster of astronaut cats
+and the missions they are scheduled to fly. The package ships with a reusable
+service layer, a simple JSON-backed controller, and an ergonomic command-line
+interface.
+
+## Installation
+
+```bash
+pip install .
+```
+
+This uses the configuration in `pyproject.toml` to build the package with
+[`hatchling`](https://hatch.pypa.io/).
+
+## Command-line interface
+
+The package exposes a console script named `astrocatlobby`. Example usage:
+
+```bash
+# Register a new astro-cat
+astrocatlobby register Nova Captain
+
+# Assign a mission
+astrocatlobby assign Nova "Inspect moon base"
+
+# Show the current roster
+astrocatlobby summary
+```
+
+By default the CLI stores its state in `~/.astrocatlobby.json`. You can override
+this with the `--storage` flag:
+
+```bash
+astrocatlobby --storage /tmp/cats.json summary
+```
+
+## Python API
+
+You can also embed the lobby in another application via the service layer:
+
+```python
+from astrocatlobby import LobbyService
+
+service = LobbyService()
+service.register_cat("Nova", "Captain")
+service.assign_mission("Nova", "Inspect moon base")
+print(service.summary_lines())
+```
+
+## Tests
+
+The project uses `pytest` for testing. Install the optional test dependencies
+and run the suite with:
+
+```bash
+pip install .[test]
+pytest
+```
+
+The CLI tests exercise the command in-process, so they run quickly and do not
+require writing to user directories.

--- a/astrocatlobby/__init__.py
+++ b/astrocatlobby/__init__.py
@@ -1,0 +1,7 @@
+"""Astrocat Lobby package."""
+from .models import AstroCat
+from .services import LobbyService
+from .controllers import LobbyController
+
+__all__ = ["AstroCat", "LobbyService", "LobbyController"]
+__version__ = "0.1.0"

--- a/astrocatlobby/cli.py
+++ b/astrocatlobby/cli.py
@@ -1,0 +1,75 @@
+"""Command line interface for the Astrocat Lobby."""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+from .controllers import LobbyController
+
+DEFAULT_STORAGE = Path.home() / ".astrocatlobby.json"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Manage the Astrocat Lobby")
+    parser.add_argument(
+        "--storage",
+        type=Path,
+        default=DEFAULT_STORAGE,
+        help="Path to the JSON file used to store lobby data.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    register = subparsers.add_parser("register", help="Register a new astro-cat")
+    register.add_argument("name", help="Name of the cat")
+    register.add_argument("rank", help="Rank or title of the cat")
+
+    assign = subparsers.add_parser("assign", help="Assign a mission to a cat")
+    assign.add_argument("name", help="Name of the cat")
+    assign.add_argument("mission", help="Description of the mission")
+
+    subparsers.add_parser("summary", help="Show a summary of the lobby")
+
+    return parser
+
+
+def _ensure_controller(storage: Path) -> LobbyController:
+    controller = LobbyController(storage_path=storage)
+    controller.load()
+    return controller
+
+
+def _print_lines(lines: Iterable[str]) -> None:
+    for line in lines:
+        print(line)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    """Run the CLI."""
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    controller = _ensure_controller(args.storage)
+
+    if args.command == "register":
+        cat = controller.register_cat(args.name, args.rank)
+        print(f"Registered {cat.name} with rank {cat.rank}.")
+        return 0
+    if args.command == "assign":
+        cat = controller.assign_mission(args.name, args.mission)
+        print(f"Assigned mission to {cat.name}: {cat.missions[-1]}")
+        return 0
+    if args.command == "summary":
+        summary = controller.summary()
+        _print_lines(summary.splitlines())
+        if not summary:
+            print("No cats registered.")
+        return 0
+
+    parser.print_help()
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/astrocatlobby/controllers.py
+++ b/astrocatlobby/controllers.py
@@ -1,0 +1,61 @@
+"""High level orchestration for the Astrocat Lobby."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Iterable, Optional
+
+from .models import AstroCat
+from .services import LobbyService
+
+
+class LobbyController:
+    """Controller that coordinates persistence and the service layer."""
+
+    def __init__(
+        self,
+        service: Optional[LobbyService] = None,
+        storage_path: Optional[Path] = None,
+    ) -> None:
+        self.service = service or LobbyService()
+        self._storage_path = storage_path
+
+    @property
+    def storage_path(self) -> Optional[Path]:
+        """Return the configured storage path."""
+        return self._storage_path
+
+    def load(self) -> None:
+        """Load state from storage if available."""
+        if not self._storage_path or not self._storage_path.exists():
+            return
+        data = json.loads(self._storage_path.read_text(encoding="utf-8"))
+        self.service = LobbyService.from_dict(data)
+
+    def save(self) -> None:
+        """Persist the current state to storage."""
+        if not self._storage_path:
+            return
+        self._storage_path.parent.mkdir(parents=True, exist_ok=True)
+        data = self.service.to_dict()
+        self._storage_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+    def register_cat(self, name: str, rank: str) -> AstroCat:
+        """Register a new cat and persist the change."""
+        cat = self.service.register_cat(name=name, rank=rank)
+        self.save()
+        return cat
+
+    def assign_mission(self, name: str, mission: str) -> AstroCat:
+        """Assign a mission to a cat and persist the change."""
+        cat = self.service.assign_mission(name=name, mission=mission)
+        self.save()
+        return cat
+
+    def list_cats(self) -> Iterable[AstroCat]:
+        """Return all registered cats."""
+        return self.service.list_cats()
+
+    def summary(self) -> str:
+        """Return a formatted summary of the lobby."""
+        return "\n".join(self.service.summary_lines())

--- a/astrocatlobby/models.py
+++ b/astrocatlobby/models.py
@@ -1,0 +1,53 @@
+"""Data models used by the Astrocat Lobby."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List
+
+
+@dataclass
+class AstroCat:
+    """Represents an astronaut cat registered with the lobby."""
+
+    name: str
+    rank: str
+    missions: List[str] = field(default_factory=list)
+
+    def assign_mission(self, mission: str) -> None:
+        """Assign a new mission to the cat."""
+        mission = mission.strip()
+        if not mission:
+            raise ValueError("Mission name cannot be empty.")
+        self.missions.append(mission)
+
+    def to_dict(self) -> Dict[str, object]:
+        """Return a serialisable representation of the cat."""
+        return {
+            "name": self.name,
+            "rank": self.rank,
+            "missions": list(self.missions),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, object]) -> "AstroCat":
+        """Create a cat instance from serialised data."""
+        missions = list(data.get("missions", []))
+        return cls(name=str(data["name"]), rank=str(data["rank"]), missions=missions)
+
+    def summary(self) -> str:
+        """Return a human readable description of the cat's status."""
+        if self.missions:
+            mission_report = ", ".join(self.missions)
+        else:
+            mission_report = "No missions assigned"
+        return f"{self.name} ({self.rank}) — {mission_report}"
+
+
+def serialise_cats(cats: Iterable[AstroCat]) -> List[Dict[str, object]]:
+    """Serialise an iterable of cats for persistence."""
+    return [cat.to_dict() for cat in cats]
+
+
+def deserialise_cats(data: Iterable[Dict[str, object]]) -> List[AstroCat]:
+    """Load cats from serialised data."""
+    return [AstroCat.from_dict(item) for item in data]

--- a/astrocatlobby/services.py
+++ b/astrocatlobby/services.py
@@ -1,0 +1,63 @@
+"""Business logic for managing astro-cats."""
+from __future__ import annotations
+
+from collections import OrderedDict
+from typing import Dict, Iterable, List, MutableMapping, Optional
+
+from .models import AstroCat, deserialise_cats, serialise_cats
+
+
+class LobbyService:
+    """Service layer for registering cats and managing missions."""
+
+    def __init__(self, cats: Optional[Iterable[AstroCat]] = None) -> None:
+        self._cats: "OrderedDict[str, AstroCat]" = OrderedDict()
+        if cats:
+            for cat in cats:
+                self._cats[cat.name] = cat
+
+    def register_cat(self, name: str, rank: str) -> AstroCat:
+        """Register a new cat with the given rank."""
+        if name in self._cats:
+            raise ValueError(f"A cat named {name!r} is already registered.")
+        cat = AstroCat(name=name, rank=rank)
+        self._cats[name] = cat
+        return cat
+
+    def assign_mission(self, name: str, mission: str) -> AstroCat:
+        """Assign a mission to an existing cat."""
+        try:
+            cat = self._cats[name]
+        except KeyError as exc:
+            raise ValueError(f"Unknown cat: {name!r}") from exc
+        cat.assign_mission(mission)
+        return cat
+
+    def get_cat(self, name: str) -> AstroCat:
+        """Return a registered cat."""
+        try:
+            return self._cats[name]
+        except KeyError as exc:
+            raise ValueError(f"Unknown cat: {name!r}") from exc
+
+    def list_cats(self) -> List[AstroCat]:
+        """Return all registered cats in registration order."""
+        return list(self._cats.values())
+
+    def to_dict(self) -> Dict[str, object]:
+        """Serialise the lobby state."""
+        return {"cats": serialise_cats(self._cats.values())}
+
+    @classmethod
+    def from_dict(cls, data: MutableMapping[str, object]) -> "LobbyService":
+        """Create a service from serialised state."""
+        cats_data = data.get("cats", [])
+        cats = deserialise_cats(cats_data)
+        return cls(cats=cats)
+
+    def summary_lines(self) -> List[str]:
+        """Return a textual summary for each cat."""
+        cats = self.list_cats()
+        if not cats:
+            return ["No cats registered."]
+        return [cat.summary() for cat in cats]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "astrocatlobby"
+version = "0.1.0"
+description = "Manage a roster of astronaut cats and their missions."
+authors = [{ name = "Astrocat Lobby Maintainers" }]
+readme = "README.md"
+requires-python = ">=3.9"
+dependencies = []
+
+[project.scripts]
+astrocatlobby = "astrocatlobby.cli:main"
+
+[project.optional-dependencies]
+test = ["pytest"]
+
+[tool.pytest.ini_options]
+addopts = "-ra"
+pythonpath = ["."]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+
+import pytest
+
+from astrocatlobby import cli
+
+
+@pytest.mark.parametrize("command", [["summary"]])
+def test_summary_on_empty_state(tmp_path: Path, capsys, command):
+    storage = tmp_path / "state.json"
+    exit_code = cli.main(["--storage", str(storage), *command])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert "No cats registered" in captured.out
+
+
+def test_register_and_assign_via_cli(tmp_path: Path, capsys):
+    storage = tmp_path / "state.json"
+
+    exit_code = cli.main([
+        "--storage",
+        str(storage),
+        "register",
+        "Nova",
+        "Captain",
+    ])
+    assert exit_code == 0
+
+    exit_code = cli.main([
+        "--storage",
+        str(storage),
+        "assign",
+        "Nova",
+        "Inspect moon base",
+    ])
+    assert exit_code == 0
+
+    exit_code = cli.main(["--storage", str(storage), "summary"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert "Nova" in captured.out
+    assert "Inspect moon base" in captured.out

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,0 +1,45 @@
+from astrocatlobby.models import AstroCat
+from astrocatlobby.services import LobbyService
+
+
+def test_register_and_list_cats():
+    service = LobbyService()
+    service.register_cat("Nova", "Captain")
+    service.register_cat("Comet", "Lieutenant")
+
+    cats = service.list_cats()
+    assert [cat.name for cat in cats] == ["Nova", "Comet"]
+
+
+def test_assign_mission_updates_cat():
+    service = LobbyService()
+    service.register_cat("Luna", "Specialist")
+    updated = service.assign_mission("Luna", "Survey the Andromeda sector")
+
+    assert updated.missions == ["Survey the Andromeda sector"]
+    assert service.get_cat("Luna").missions == ["Survey the Andromeda sector"]
+
+
+def test_duplicate_registration_is_rejected():
+    service = LobbyService()
+    service.register_cat("Nova", "Captain")
+
+    try:
+        service.register_cat("Nova", "Commander")
+    except ValueError as exc:
+        assert "already registered" in str(exc)
+    else:
+        raise AssertionError("Expected duplicate registration to fail")
+
+
+def test_serialisation_roundtrip():
+    service = LobbyService()
+    cat = service.register_cat("Nova", "Captain")
+    service.assign_mission("Nova", "Inspect moon base")
+
+    data = service.to_dict()
+    restored = LobbyService.from_dict(data)
+
+    restored_cat = restored.get_cat("Nova")
+    assert restored_cat.rank == cat.rank
+    assert restored_cat.missions == ["Inspect moon base"]


### PR DESCRIPTION
## Summary
- add the astrocatlobby package with models, services, controller, and CLI for managing astronaut cats
- configure packaging metadata and console entry point via `pyproject.toml`
- document installation and usage and add pytest-based service and CLI tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0ef42588c832484ac92e9a2aa77da