### PR TITLE
Add pygame-style game client and entry point

### DIFF
--- a/astrocatlobby/game/__init__.py
+++ b/astrocatlobby/game/__init__.py
@@ -1,0 +1,11 @@
+"""Game package for Astrocat Lobby.
+
+This module exposes the :class:`GameClient` which provides an optional
+pygame-powered experience for the project.  The rest of the package
+contains small abstractions that make the game loop testable even when
+pygame is not installed in the execution environment.
+"""
+
+from .client import GameClient
+
+__all__ = ["GameClient"]

--- a/astrocatlobby/game/__main__.py
+++ b/astrocatlobby/game/__main__.py
@@ -1,0 +1,16 @@
+"""Console entry point for the Astrocat Lobby game."""
+
+from __future__ import annotations
+
+from .client import GameClient
+
+
+def main() -> None:
+    """Launch the lobby game using the default configuration."""
+
+    client = GameClient()
+    client.start()
+
+
+if __name__ == "__main__":
+    main()

--- a/astrocatlobby/game/client.py
+++ b/astrocatlobby/game/client.py
@@ -1,0 +1,55 @@
+"""Public entry point for launching the Astrocat Lobby game."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional, Sequence
+
+from .engine import GameEngine
+from .scenes import Camera, Player, SideScrollingScene, TileMap, create_default_scene
+
+DEFAULT_MAP: Sequence[str] = (
+    "........................................",
+    "........................................",
+    "........................................",
+    "........................................",
+    "........................................",
+    "........................................",
+    "...............####.....................",
+    "........................................",
+    "##############################....######",
+    "........................................",
+)
+
+
+@dataclass
+class GameClient:
+    """High level wrapper around :class:`GameEngine` and :class:`SideScrollingScene`."""
+
+    engine: GameEngine = field(default_factory=GameEngine)
+    scene: Optional[SideScrollingScene] = None
+
+    def __post_init__(self) -> None:
+        if self.scene is None:
+            self.scene = self.create_scene_from_layout(DEFAULT_MAP)
+
+    # --- Scene construction ---------------------------------------------
+    def create_scene_from_layout(self, layout: Sequence[str]) -> SideScrollingScene:
+        tile_map = TileMap(layout)
+        player_start_x = tile_map.tile_size * 2
+        player_start_y = tile_map.tile_size * 4
+        player = Player(x=player_start_x, y=player_start_y)
+        camera = Camera(width=self.engine.state.width, height=self.engine.state.height)
+        return SideScrollingScene(tile_map=tile_map, player=player, camera=camera)
+
+    def load_scene(self, layout: Sequence[str]) -> None:
+        self.scene = self.create_scene_from_layout(layout)
+
+    # --- Game loop ------------------------------------------------------
+    def start(self) -> None:
+        if not self.scene:
+            self.scene = create_default_scene()
+        self.engine.run(self.scene)
+
+
+__all__ = ["GameClient"]

--- a/astrocatlobby/game/engine.py
+++ b/astrocatlobby/game/engine.py
@@ -1,0 +1,156 @@
+"""Utility classes for managing the game loop and backend integration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from types import ModuleType
+from typing import Callable, Optional
+
+BackendInitHook = Callable[["GameEngine"], None]
+
+
+class MissingBackendError(RuntimeError):
+    """Raised when the user tries to start the game without pygame installed."""
+
+
+@dataclass
+class EngineState:
+    """Runtime state shared between the engine and active scenes."""
+
+    backend: Optional[ModuleType]
+    screen: Optional[object] = None
+    clock: Optional[object] = None
+    should_exit: bool = False
+    fps: int = 60
+    width: int = 800
+    height: int = 600
+
+
+@dataclass
+class GameEngine:
+    """Minimal pygame-style engine abstraction.
+
+    The engine keeps track of display properties and exposes a ``run`` method
+    that executes a typical render/update loop.  The pygame dependency is
+    optional: if it is not installed the engine still performs logical
+    updates so unit tests can interact with the scene without a graphical
+    backend.
+    """
+
+    width: int = 800
+    height: int = 600
+    fps: int = 60
+    init_hook: Optional[BackendInitHook] = None
+    _state: EngineState = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        backend = self._import_backend()
+        self._state = EngineState(
+            backend=backend,
+            fps=self.fps,
+            width=self.width,
+            height=self.height,
+        )
+
+    @staticmethod
+    def _import_backend() -> Optional[ModuleType]:
+        try:
+            import pygame  # type: ignore
+
+            return pygame
+        except ModuleNotFoundError:
+            return None
+
+    @property
+    def backend(self) -> Optional[ModuleType]:
+        return self._state.backend
+
+    @property
+    def state(self) -> EngineState:
+        return self._state
+
+    def initialise(self) -> None:
+        """Initialise the backend if available and run a custom hook."""
+
+        if self.backend:
+            self.backend.init()
+            self._state.screen = self.backend.display.set_mode((self.width, self.height))
+            self.backend.display.set_caption("Astrocat Lobby")
+            self._state.clock = self.backend.time.Clock()
+
+        if self.init_hook:
+            self.init_hook(self)
+
+    def run(self, scene: "BaseScene") -> None:
+        """Run the update/render loop until the scene requests an exit."""
+
+        if self.backend is None and scene.requires_backend:
+            raise MissingBackendError(
+                "pygame is required for this scene but is not installed. "
+                "Install `pygame` to launch the lobby game."
+            )
+
+        scene.bind_engine(self)
+        self.initialise()
+        scene.startup()
+
+        while not self._state.should_exit:
+            dt = scene.poll_events()
+            scene.update(dt)
+            scene.render()
+
+        scene.shutdown()
+        if self.backend:
+            self.backend.quit()
+
+
+class BaseScene:
+    """Small protocol for scenes used by :class:`GameEngine`."""
+
+    requires_backend: bool = True
+
+    def __init__(self) -> None:
+        self.engine: Optional[GameEngine] = None
+
+    # --- Engine binding -------------------------------------------------
+    def bind_engine(self, engine: GameEngine) -> None:
+        self.engine = engine
+
+    # --- Lifecycle hooks ------------------------------------------------
+    def startup(self) -> None:
+        """Perform scene initialisation."""
+
+    def shutdown(self) -> None:
+        """Clean up resources when the game exits."""
+
+    # --- Game loop methods ----------------------------------------------
+    def poll_events(self) -> float:
+        """Poll backend events and return elapsed time in seconds."""
+
+        if not self.engine:
+            return 0.0
+
+        backend = self.engine.backend
+        if backend:
+            elapsed_ms = self.engine.state.clock.tick(self.engine.state.fps)
+            for event in backend.event.get():
+                if event.type == backend.QUIT:
+                    self.engine.state.should_exit = True
+            return elapsed_ms / 1000.0
+
+        # When no backend is available we simply progress by one frame.
+        return 1.0 / self.engine.state.fps
+
+    def update(self, dt: float) -> None:
+        """Update the scene logic for the current frame."""
+
+    def render(self) -> None:
+        """Render the scene using the active backend."""
+
+
+__all__ = [
+    "BaseScene",
+    "EngineState",
+    "GameEngine",
+    "MissingBackendError",
+]

--- a/astrocatlobby/game/scenes.py
+++ b/astrocatlobby/game/scenes.py
@@ -1,0 +1,193 @@
+"""Scene implementations used by the Astrocat Lobby game client."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional, Sequence, Tuple
+
+from .engine import BaseScene
+
+Tile = Tuple[int, int, int]
+Color = Tuple[int, int, int]
+
+# Basic palette
+BACKGROUND_COLOR: Color = (25, 25, 40)
+TILE_COLOR: Color = (80, 200, 120)
+PLAYER_COLOR: Color = (240, 240, 255)
+
+
+@dataclass
+class Camera:
+    width: int
+    height: int
+    x: float = 0
+    y: float = 0
+
+    def follow(self, target_x: float, target_y: float) -> None:
+        self.x = max(0.0, target_x - self.width / 2)
+        self.y = max(0.0, target_y - self.height / 2)
+
+
+@dataclass
+class Player:
+    x: float
+    y: float
+    vx: float = 0
+    vy: float = 0
+    on_ground: bool = False
+
+    def apply_gravity(self, dt: float, gravity: float = 1200.0) -> None:
+        self.vy += gravity * dt
+
+    def move(self, dt: float) -> None:
+        self.x += self.vx * dt
+        self.y += self.vy * dt
+
+
+class TileMap:
+    """Simple tile map represented as a matrix of ``0``/``1`` values."""
+
+    def __init__(self, layout: Sequence[str], tile_size: int = 32) -> None:
+        self.layout = [list(row) for row in layout]
+        self.rows = len(layout)
+        self.cols = len(layout[0]) if layout else 0
+        self.tile_size = tile_size
+
+    def tiles(self) -> List[Tile]:
+        solid: List[Tile] = []
+        for row_index, row in enumerate(self.layout):
+            for col_index, value in enumerate(row):
+                if value == "#":
+                    solid.append(
+                        (
+                            col_index * self.tile_size,
+                            row_index * self.tile_size,
+                            self.tile_size,
+                        )
+                    )
+        return solid
+
+    def clamp_position(self, player: Player) -> None:
+        max_x = (self.cols - 1) * self.tile_size
+        max_y = (self.rows - 1) * self.tile_size
+        player.x = max(0, min(player.x, max_x))
+        if player.y > max_y:
+            player.y = max_y
+            player.vy = 0
+            player.on_ground = True
+
+
+class SideScrollingScene(BaseScene):
+    """A small platformer scene with a scrolling camera."""
+
+    requires_backend = True
+
+    def __init__(self, tile_map: TileMap, player: Player, camera: Optional[Camera] = None) -> None:
+        super().__init__()
+        self.map = tile_map
+        self.player = player
+        self.camera = camera or Camera(width=800, height=600)
+        self.gravity = 1600.0
+        self.jump_speed = -650.0
+        self.move_speed = 250.0
+
+    # --- Lifecycle ------------------------------------------------------
+    def startup(self) -> None:
+        if self.engine and self.engine.backend:
+            backend = self.engine.backend
+            backend.font.init()
+            self._font = backend.font.Font(None, 24)
+        else:
+            self._font = None
+
+    def shutdown(self) -> None:
+        self._font = None
+
+    # --- Game loop ------------------------------------------------------
+    def poll_events(self) -> float:
+        dt = super().poll_events()
+        if self.engine and self.engine.backend:
+            backend = self.engine.backend
+            keys = backend.key.get_pressed()
+            self.handle_input(keys)
+        return dt
+
+    def update(self, dt: float) -> None:
+        self.player.apply_gravity(dt, gravity=self.gravity)
+        self.player.move(dt)
+        self.map.clamp_position(self.player)
+        self.camera.follow(self.player.x, self.player.y)
+
+    def render(self) -> None:
+        if not self.engine or not self.engine.backend:
+            # Running in headless mode: nothing to render.
+            return
+
+        backend = self.engine.backend
+        screen = self.engine.state.screen
+        screen.fill(BACKGROUND_COLOR)
+
+        # Draw tiles
+        for tile_x, tile_y, tile_size in self.map.tiles():
+            rect = backend.Rect(tile_x - self.camera.x, tile_y - self.camera.y, tile_size, tile_size)
+            backend.draw.rect(screen, TILE_COLOR, rect)
+
+        # Draw player
+        player_rect = backend.Rect(
+            self.player.x - self.camera.x,
+            self.player.y - self.camera.y,
+            self.map.tile_size,
+            self.map.tile_size,
+        )
+        backend.draw.rect(screen, PLAYER_COLOR, player_rect)
+
+        if self._font:
+            text = self._font.render("Astrocat Lobby", True, PLAYER_COLOR)
+            screen.blit(text, (20, 20))
+
+        backend.display.flip()
+
+    # --- Input ----------------------------------------------------------
+    def handle_input(self, key_state: Sequence[bool]) -> None:
+        if not self.engine or not self.engine.backend:
+            return
+
+        backend = self.engine.backend
+        if key_state[backend.K_LEFT] or key_state[backend.K_a]:
+            self.player.vx = -self.move_speed
+        elif key_state[backend.K_RIGHT] or key_state[backend.K_d]:
+            self.player.vx = self.move_speed
+        else:
+            self.player.vx = 0
+
+        if (key_state[backend.K_SPACE] or key_state[backend.K_UP]) and self.player.on_ground:
+            self.player.vy = self.jump_speed
+            self.player.on_ground = False
+
+
+def create_default_scene() -> SideScrollingScene:
+    layout = [
+        "........................................",
+        "........................................",
+        "........................................",
+        "........................................",
+        "........................................",
+        "........................................",
+        "...............####.....................",
+        "........................................",
+        "##############################....######",
+        "........................................",
+    ]
+    tile_map = TileMap(layout)
+    player = Player(x=tile_map.tile_size * 2, y=tile_map.tile_size * 4)
+    camera = Camera(width=800, height=600)
+    return SideScrollingScene(tile_map, player, camera)
+
+
+__all__ = [
+    "Camera",
+    "Player",
+    "SideScrollingScene",
+    "TileMap",
+    "create_default_scene",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = []
 
 [project.scripts]
 astrocatlobby = "astrocatlobby.cli:main"
+astrocatlobby-game = "astrocatlobby.game.__main__:main"
 
 [project.optional-dependencies]
 test = ["pytest"]


### PR DESCRIPTION
## Summary
- add a new `astrocatlobby.game` package with a lightweight engine abstraction
- implement a side-scrolling scene, player logic, and game client wrapper
- expose an `astrocatlobby-game` console entry point that launches the client

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d17e5249c883249970ccd8d98b65b5