### PR TITLE
Add game asset loader and client support

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,47 @@ pytest
 
 The CLI tests exercise the command in-process, so they run quickly and do not
 require writing to user directories.
+
+## Game assets
+
+The experimental arcade client in `astrocatlobby.game.client` loads its sprite
+animations from a manifest-driven asset pack. To prepare a pack, create a
+directory containing a sprite sheet image and a `manifest.json` file with the
+following structure:
+
+```json
+{
+  "sprite_sheet": {
+    "image": "cats.png",
+    "frame_width": 32,
+    "frame_height": 32,
+    "margin": 0,
+    "spacing": 0
+  },
+  "animations": {
+    "idle": {
+      "frames": [0, 1, 2, 1],
+      "frame_duration": 0.12,
+      "loop": true
+    },
+    "pounce": {
+      "frames": [8, 9, 10, 11, 12],
+      "frame_duration": 0.08,
+      "loop": false
+    }
+  }
+}
+```
+
+The frame indices reference tiles sliced from the sprite sheet using the
+dimensions, margin and spacing specified in the manifest. Sprite sheets should
+be PNG images so the loader can determine their dimensions. When running the
+client you can point to a custom asset pack by supplying the directory via the
+`--assets` flag:
+
+```bash
+python -m astrocatlobby.game.client --assets /path/to/asset-pack
+```
+
+If your pack uses a different manifest filename you can provide it with
+`--manifest custom.json`.

--- a/astrocatlobby/game/__init__.py
+++ b/astrocatlobby/game/__init__.py
@@ -1,0 +1,28 @@
+"""Game-specific utilities and clients for Astrocat Lobby."""
+from .assets import (
+    AnimationSequence,
+    AssetManifest,
+    LoadedAnimation,
+    LoadedAssets,
+    SpriteFrame,
+    SpriteSheet,
+    SpriteSheetConfig,
+    load_assets_from_directory,
+    load_manifest,
+)
+from .client import GameClient, build_parser, main
+
+__all__ = [
+    "AnimationSequence",
+    "AssetManifest",
+    "GameClient",
+    "LoadedAnimation",
+    "LoadedAssets",
+    "SpriteFrame",
+    "SpriteSheet",
+    "SpriteSheetConfig",
+    "build_parser",
+    "load_assets_from_directory",
+    "load_manifest",
+    "main",
+]

--- a/astrocatlobby/game/assets.py
+++ b/astrocatlobby/game/assets.py
@@ -1,0 +1,293 @@
+"""Asset manifest handling for the Astrocat game client."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, MutableMapping, Sequence, Tuple
+
+
+class AssetManifestError(RuntimeError):
+    """Raised when an asset manifest cannot be parsed or loaded."""
+
+
+@dataclass(frozen=True)
+class SpriteSheetConfig:
+    """Configuration describing a sprite sheet image."""
+
+    image: Path
+    frame_width: int
+    frame_height: int
+    margin: int = 0
+    spacing: int = 0
+
+    def resolve(self, root: Path) -> "SpriteSheetConfig":
+        """Return a copy with the image path resolved relative to ``root``."""
+
+        image = self.image
+        if not image.is_absolute():
+            image = root / image
+        return SpriteSheetConfig(
+            image=image,
+            frame_width=self.frame_width,
+            frame_height=self.frame_height,
+            margin=self.margin,
+            spacing=self.spacing,
+        )
+
+
+@dataclass(frozen=True)
+class AnimationSequence:
+    """Configuration describing a named animation."""
+
+    name: str
+    frames: Sequence[int]
+    frame_duration: float
+    loop: bool = True
+
+
+@dataclass(frozen=True)
+class AssetManifest:
+    """Full manifest describing the available sprite assets."""
+
+    sprite_sheet: SpriteSheetConfig
+    animations: Dict[str, AnimationSequence]
+
+
+@dataclass(frozen=True)
+class SpriteFrame:
+    """A rectangular slice of a sprite sheet."""
+
+    index: int
+    box: Tuple[int, int, int, int]
+
+
+@dataclass
+class SpriteSheet:
+    """Loaded sprite sheet metadata and raw image bytes."""
+
+    path: Path
+    width: int
+    height: int
+    data: bytes
+
+    @property
+    def size(self) -> Tuple[int, int]:
+        """Return the (width, height) pair for convenience."""
+
+        return self.width, self.height
+
+
+@dataclass
+class LoadedAnimation:
+    """Animation data ready for rendering."""
+
+    name: str
+    frames: List[SpriteFrame]
+    frame_duration: float
+    loop: bool
+
+
+@dataclass
+class LoadedAssets:
+    """Container bundling a sprite sheet and the derived animations."""
+
+    sprite_sheet: SpriteSheet
+    animations: Dict[str, LoadedAnimation]
+
+
+def _ensure_positive(value: int, field: str) -> None:
+    if value <= 0:
+        raise AssetManifestError(f"{field} must be positive (got {value!r}).")
+
+
+def _parse_sprite_sheet(data: MutableMapping[str, object], root: Path) -> SpriteSheetConfig:
+    try:
+        image_field = data["image"]
+        frame_width = int(data["frame_width"])
+        frame_height = int(data["frame_height"])
+        margin = int(data.get("margin", 0))
+        spacing = int(data.get("spacing", 0))
+    except KeyError as exc:
+        raise AssetManifestError("Sprite sheet configuration is missing required keys.") from exc
+    except (TypeError, ValueError) as exc:
+        raise AssetManifestError("Sprite sheet configuration has invalid values.") from exc
+
+    _ensure_positive(frame_width, "frame_width")
+    _ensure_positive(frame_height, "frame_height")
+    if margin < 0 or spacing < 0:
+        raise AssetManifestError("margin and spacing must be zero or positive.")
+
+    image_path = Path(str(image_field))
+    return SpriteSheetConfig(
+        image=image_path,
+        frame_width=frame_width,
+        frame_height=frame_height,
+        margin=margin,
+        spacing=spacing,
+    ).resolve(root)
+
+
+def _parse_animation(name: str, data: MutableMapping[str, object]) -> AnimationSequence:
+    try:
+        frames_field = data["frames"]
+        frame_duration = float(data["frame_duration"])
+        loop = bool(data.get("loop", True))
+    except KeyError as exc:
+        raise AssetManifestError(f"Animation {name!r} is missing required keys.") from exc
+    except (TypeError, ValueError) as exc:
+        raise AssetManifestError(f"Animation {name!r} has invalid values.") from exc
+
+    if isinstance(frames_field, Iterable) and not isinstance(frames_field, (str, bytes)):
+        frames = [int(frame) for frame in frames_field]
+    else:
+        raise AssetManifestError(f"Animation {name!r} frames must be an iterable of indices.")
+
+    if not frames:
+        raise AssetManifestError(f"Animation {name!r} must define at least one frame.")
+
+    for index in frames:
+        if index < 0:
+            raise AssetManifestError(f"Animation {name!r} contains a negative frame index: {index}")
+
+    if frame_duration <= 0:
+        raise AssetManifestError(
+            f"Animation {name!r} frame_duration must be positive (got {frame_duration!r})."
+        )
+
+    return AnimationSequence(name=name, frames=frames, frame_duration=frame_duration, loop=loop)
+
+
+def load_manifest(path: Path) -> AssetManifest:
+    """Load a manifest JSON file into configuration dataclasses."""
+
+    if not path.exists():
+        raise AssetManifestError(f"No manifest found at {path}.")
+
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise AssetManifestError(f"Manifest {path} is not valid JSON.") from exc
+
+    root = path.parent
+    try:
+        sheet_data = data["sprite_sheet"]
+        animations_data = data["animations"]
+    except KeyError as exc:
+        raise AssetManifestError("Manifest must define 'sprite_sheet' and 'animations'.") from exc
+
+    if not isinstance(animations_data, MutableMapping):
+        raise AssetManifestError("'animations' must be an object mapping names to configs.")
+
+    sprite_sheet = _parse_sprite_sheet(sheet_data, root)
+    animations: Dict[str, AnimationSequence] = {}
+    for name, anim_data in animations_data.items():
+        if not isinstance(anim_data, MutableMapping):
+            raise AssetManifestError(f"Animation {name!r} must be a mapping of properties.")
+        animations[name] = _parse_animation(name, anim_data)
+
+    if not animations:
+        raise AssetManifestError("Manifest must define at least one animation.")
+
+    return AssetManifest(sprite_sheet=sprite_sheet, animations=animations)
+
+
+PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
+
+
+def _read_png_size(data: bytes) -> Tuple[int, int]:
+    if len(data) < 24 or not data.startswith(PNG_SIGNATURE):
+        raise AssetManifestError("Sprite sheets must be valid PNG files.")
+    # IHDR chunk follows the signature. Its first 8 bytes are width/height.
+    width = int.from_bytes(data[16:20], "big")
+    height = int.from_bytes(data[20:24], "big")
+    if width <= 0 or height <= 0:
+        raise AssetManifestError("Sprite sheet reported non-positive dimensions.")
+    return width, height
+
+
+def _load_sprite_sheet(path: Path) -> SpriteSheet:
+    try:
+        data = path.read_bytes()
+    except FileNotFoundError as exc:
+        raise AssetManifestError(f"Sprite sheet image {path} could not be found.") from exc
+    except OSError as exc:
+        raise AssetManifestError(f"Failed to load sprite sheet image {path}.") from exc
+
+    width, height = _read_png_size(data)
+    return SpriteSheet(path=path, width=width, height=height, data=data)
+
+
+def _calculate_grid(sheet: SpriteSheet, config: SpriteSheetConfig) -> Tuple[int, int]:
+    usable_width = sheet.width - 2 * config.margin
+    usable_height = sheet.height - 2 * config.margin
+
+    if usable_width <= 0 or usable_height <= 0:
+        raise AssetManifestError(
+            "Sprite sheet is too small for the configured margin and frame size."
+        )
+
+    if config.frame_width > usable_width or config.frame_height > usable_height:
+        raise AssetManifestError(
+            "Frame dimensions are larger than the usable sprite sheet area."
+        )
+
+    step_x = config.frame_width + config.spacing
+    step_y = config.frame_height + config.spacing
+
+    columns = 1 + max(0, (usable_width - config.frame_width) // step_x)
+    rows = 1 + max(0, (usable_height - config.frame_height) // step_y)
+
+    return columns, rows
+
+
+def _slice_sprite_sheet(sheet: SpriteSheet, config: SpriteSheetConfig) -> List[SpriteFrame]:
+    columns, rows = _calculate_grid(sheet, config)
+    frames: List[SpriteFrame] = []
+
+    for row in range(rows):
+        for column in range(columns):
+            left = config.margin + column * (config.frame_width + config.spacing)
+            top = config.margin + row * (config.frame_height + config.spacing)
+            box = (left, top, left + config.frame_width, top + config.frame_height)
+            frames.append(SpriteFrame(index=len(frames), box=box))
+
+    if not frames:
+        raise AssetManifestError(
+            "Sprite sheet dimensions and configuration produced zero frames; "
+            "check frame size, margin, and spacing."
+        )
+
+    return frames
+
+
+def load_assets(manifest: AssetManifest) -> LoadedAssets:
+    """Load image data for the provided manifest."""
+
+    sprite_sheet = _load_sprite_sheet(manifest.sprite_sheet.image)
+    frames = _slice_sprite_sheet(sprite_sheet, manifest.sprite_sheet)
+
+    animations: Dict[str, LoadedAnimation] = {}
+    for name, animation in manifest.animations.items():
+        try:
+            frame_images = [frames[index] for index in animation.frames]
+        except IndexError as exc:
+            raise AssetManifestError(
+                f"Animation {name!r} references a frame that does not exist in the sprite sheet."
+            ) from exc
+        animations[name] = LoadedAnimation(
+            name=name,
+            frames=frame_images,
+            frame_duration=animation.frame_duration,
+            loop=animation.loop,
+        )
+
+    return LoadedAssets(sprite_sheet=sprite_sheet, animations=animations)
+
+
+def load_assets_from_directory(directory: Path, manifest_name: str = "manifest.json") -> LoadedAssets:
+    """Load assets given a directory containing a manifest and sprite sheet."""
+
+    manifest_path = directory / manifest_name
+    manifest = load_manifest(manifest_path)
+    return load_assets(manifest)

--- a/astrocatlobby/game/client.py
+++ b/astrocatlobby/game/client.py
@@ -1,0 +1,76 @@
+"""Command-line entry point for running the Astrocat game client."""
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional, Sequence
+
+from .assets import LoadedAssets, load_assets_from_directory
+
+DEFAULT_MANIFEST_NAME = "manifest.json"
+
+
+def _default_asset_dir() -> Path:
+    return Path.cwd()
+
+
+@dataclass
+class GameClient:
+    """Minimal façade that prepares renderable assets for the game."""
+
+    asset_directory: Path = field(default_factory=_default_asset_dir)
+    manifest_name: str = DEFAULT_MANIFEST_NAME
+
+    def configure_assets(self, asset_directory: Path, manifest_name: Optional[str] = None) -> None:
+        """Update the asset directory and manifest name used by the client."""
+
+        self.asset_directory = asset_directory
+        if manifest_name:
+            self.manifest_name = manifest_name
+
+    def load_assets(self) -> LoadedAssets:
+        """Load and return textures and animations from the configured directory."""
+
+        return load_assets_from_directory(self.asset_directory, self.manifest_name)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run the Astrocat arcade client")
+    parser.add_argument(
+        "--assets",
+        type=Path,
+        default=_default_asset_dir(),
+        help=(
+            "Path to the asset pack directory. The directory must contain a manifest.json "
+            "file and sprite sheet referenced by that manifest."
+        ),
+    )
+    parser.add_argument(
+        "--manifest",
+        type=str,
+        default=DEFAULT_MANIFEST_NAME,
+        help="Optional manifest filename inside the asset directory (defaults to manifest.json).",
+    )
+    return parser
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    client = GameClient(asset_directory=args.assets, manifest_name=args.manifest)
+    assets = client.load_assets()
+
+    print(
+        f"Loaded sprite sheet {assets.sprite_sheet.width}x{assets.sprite_sheet.height} "
+        f"with {len(assets.animations)} animations."
+    )
+    for name, animation in assets.animations.items():
+        print(f" - {name}: {len(animation.frames)} frames @ {animation.frame_duration:.3f}s")
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation helper
+    raise SystemExit(main())

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from astrocatlobby.game.assets import (
+    AssetManifestError,
+    SpriteFrame,
+    load_assets_from_directory,
+)
+
+
+def _write_blank_png(path: Path, width: int, height: int) -> None:
+    import struct
+    import zlib
+
+    def _chunk(chunk_type: bytes, data: bytes) -> bytes:
+        return (
+            struct.pack(">I", len(data))
+            + chunk_type
+            + data
+            + struct.pack(">I", zlib.crc32(chunk_type + data) & 0xFFFFFFFF)
+        )
+
+    header = struct.pack(">IIBBBBB", width, height, 8, 6, 0, 0, 0)
+    row = b"\x00" + b"\x00\x00\x00\x00" * width
+    raw = row * height
+    compressed = zlib.compress(raw)
+    png = b"\x89PNG\r\n\x1a\n" + _chunk(b"IHDR", header) + _chunk(b"IDAT", compressed) + _chunk(b"IEND", b"")
+    path.write_bytes(png)
+
+
+@pytest.fixture()
+def asset_pack(tmp_path: Path) -> Path:
+    sheet_path = tmp_path / "cats.png"
+    _write_blank_png(sheet_path, 64, 32)
+
+    manifest = {
+        "sprite_sheet": {
+            "image": "cats.png",
+            "frame_width": 16,
+            "frame_height": 32,
+            "margin": 0,
+            "spacing": 0,
+        },
+        "animations": {
+            "walk": {"frames": [0, 1, 2, 3], "frame_duration": 0.2, "loop": True}
+        },
+    }
+    (tmp_path / "manifest.json").write_text(json.dumps(manifest))
+    return tmp_path
+
+
+def test_load_assets_from_directory(asset_pack: Path) -> None:
+    assets = load_assets_from_directory(asset_pack)
+
+    assert (assets.sprite_sheet.width, assets.sprite_sheet.height) == (64, 32)
+    assert assets.sprite_sheet.path.name == "cats.png"
+    assert set(assets.animations) == {"walk"}
+    walk = assets.animations["walk"]
+    assert walk.name == "walk"
+    assert len(walk.frames) == 4
+    assert all(isinstance(frame, SpriteFrame) for frame in walk.frames)
+    assert all(frame.box == (i * 16, 0, i * 16 + 16, 32) for i, frame in enumerate(walk.frames))
+    assert walk.frame_duration == pytest.approx(0.2)
+    assert walk.loop is True
+
+
+def test_missing_sprite_sheet(asset_pack: Path) -> None:
+    (asset_pack / "cats.png").unlink()
+
+    with pytest.raises(AssetManifestError):
+        load_assets_from_directory(asset_pack)


### PR DESCRIPTION
## Summary
- add dataclasses and helpers for loading sprite-sheet manifests and animations
- extend the experimental game client with CLI flags for choosing asset packs
- document the asset manifest format and test the asset loader

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d17e533580832495183fc0f6d3dd93