### PR TITLE
Add lobby interaction engine with collision handling

### DIFF
--- a/astrocatlobby/game/__init__.py
+++ b/astrocatlobby/game/__init__.py
@@ -1,0 +1,5 @@
+"""Game engine primitives for the Astrocat lobby experience."""
+
+from .engine import GameEngine
+
+__all__ = ["GameEngine"]

--- a/astrocatlobby/game/engine.py
+++ b/astrocatlobby/game/engine.py
@@ -1,0 +1,61 @@
+"""Simple interaction engine for the Astrocat lobby."""
+from __future__ import annotations
+
+from typing import Iterable, List, Sequence, Set
+
+from ..models import Interaction, LobbyObject, PlayerState
+
+
+class GameEngine:
+    """Coordinate player movement, collisions and interactions."""
+
+    def __init__(
+        self,
+        objects: Sequence[LobbyObject],
+        player_state: PlayerState,
+        *,
+        interaction_key: str = "space",
+    ) -> None:
+        self._objects: List[LobbyObject] = list(objects)
+        self.player_state = player_state
+        self.interaction_key = interaction_key
+
+    @property
+    def objects(self) -> Sequence[LobbyObject]:
+        """Return the registered lobby objects."""
+
+        return tuple(self._objects)
+
+    def move_player(self, dx: float, dy: float) -> bool:
+        """Attempt to move the player, preventing collisions with blocking objects.
+
+        Returns ``True`` if the movement is successful, ``False`` otherwise.
+        """
+
+        if dx == dy == 0:
+            return False
+
+        proposed_hitbox = self.player_state.offset_hitbox(dx, dy)
+        if any(obj.blocking and obj.would_collide(proposed_hitbox) for obj in self._objects):
+            return False
+
+        self.player_state.move(dx, dy)
+        return True
+
+    def colliding_objects(self) -> List[LobbyObject]:
+        """Return lobby objects whose hitboxes intersect with the player."""
+
+        return [obj for obj in self._objects if obj.collides_with(self.player_state)]
+
+    def handle_input(self, pressed_keys: Iterable[str]) -> List[Interaction]:
+        """Process a collection of pressed keys and fire relevant interactions."""
+
+        pressed: Set[str] = {key.lower() for key in pressed_keys}
+        triggered: List[Interaction] = []
+        if self.interaction_key.lower() not in pressed:
+            return triggered
+
+        for obj in self.colliding_objects():
+            if obj.interaction and obj.interaction.trigger(self.player_state, obj):
+                triggered.append(obj.interaction)
+        return triggered

--- a/astrocatlobby/models.py
+++ b/astrocatlobby/models.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Dict, Iterable, List
+from typing import Callable, Dict, Iterable, List, Optional, Tuple
 
 
 @dataclass
@@ -51,3 +51,117 @@ def serialise_cats(cats: Iterable[AstroCat]) -> List[Dict[str, object]]:
 def deserialise_cats(data: Iterable[Dict[str, object]]) -> List[AstroCat]:
     """Load cats from serialised data."""
     return [AstroCat.from_dict(item) for item in data]
+
+
+Hitbox = Tuple[float, float, float, float]
+InteractionCallback = Callable[["PlayerState", "LobbyObject"], None]
+
+
+def _calculate_hitbox(position: Tuple[float, float], size: Tuple[float, float]) -> Hitbox:
+    """Return a hitbox tuple (left, top, right, bottom) for the given geometry."""
+
+    x, y = position
+    width, height = size
+    return (x, y, x + width, y + height)
+
+
+def _overlaps(first: Hitbox, second: Hitbox) -> bool:
+    """Return ``True`` when the two hitboxes overlap."""
+
+    left_a, top_a, right_a, bottom_a = first
+    left_b, top_b, right_b, bottom_b = second
+    return not (
+        right_a <= left_b
+        or right_b <= left_a
+        or bottom_a <= top_b
+        or bottom_b <= top_a
+    )
+
+
+@dataclass
+class PlayerState:
+    """Represents the player's avatar location and facing direction."""
+
+    position: Tuple[float, float]
+    size: Tuple[float, float]
+    facing: str = "down"
+
+    def move(self, dx: float, dy: float) -> None:
+        """Move the player by the delta amount and update facing when applicable."""
+
+        x, y = self.position
+        self.position = (x + dx, y + dy)
+        if dx == dy == 0:
+            return
+
+        if abs(dx) > abs(dy):
+            self.facing = "right" if dx > 0 else "left"
+        elif dy != 0:
+            self.facing = "down" if dy > 0 else "up"
+
+    @property
+    def hitbox(self) -> Hitbox:
+        """Return the current hitbox occupied by the player."""
+
+        return _calculate_hitbox(self.position, self.size)
+
+    def offset_hitbox(self, dx: float, dy: float) -> Hitbox:
+        """Return the hitbox representing a potential movement."""
+
+        x, y = self.position
+        width, height = self.size
+        return _calculate_hitbox((x + dx, y + dy), (width, height))
+
+
+@dataclass
+class Interaction:
+    """Configuration describing how a lobby object reacts to player input."""
+
+    callback: InteractionCallback
+    prompt: Optional[str] = None
+    once: bool = False
+    _has_triggered: bool = field(default=False, init=False, repr=False)
+
+    def can_trigger(self) -> bool:
+        """Return ``True`` if the interaction is eligible to fire."""
+
+        return not (self.once and self._has_triggered)
+
+    def trigger(self, player: PlayerState, lobby_object: "LobbyObject") -> bool:
+        """Fire the configured callback when allowed.
+
+        Returns ``True`` if the callback was invoked, ``False`` otherwise.
+        """
+
+        if not self.can_trigger():
+            return False
+        self.callback(player, lobby_object)
+        self._has_triggered = True
+        return True
+
+
+@dataclass
+class LobbyObject:
+    """An interactable object placed inside the lobby scene."""
+
+    identifier: str
+    position: Tuple[float, float]
+    size: Tuple[float, float]
+    interaction: Optional[Interaction] = None
+    blocking: bool = False
+
+    @property
+    def hitbox(self) -> Hitbox:
+        """Return the object's current hitbox."""
+
+        return _calculate_hitbox(self.position, self.size)
+
+    def collides_with(self, player: PlayerState) -> bool:
+        """Return ``True`` if the object's hitbox intersects with the player's."""
+
+        return _overlaps(self.hitbox, player.hitbox)
+
+    def would_collide(self, hitbox: Hitbox) -> bool:
+        """Return ``True`` if the supplied hitbox would overlap the object."""
+
+        return _overlaps(self.hitbox, hitbox)

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,0 +1,95 @@
+"""Tests for the lobby interaction engine."""
+from __future__ import annotations
+
+from astrocatlobby.game.engine import GameEngine
+from astrocatlobby.models import Interaction, LobbyObject, PlayerState
+
+
+def test_interaction_triggers_when_overlapping_and_pressing_key():
+    triggered = []
+
+    def callback(player: PlayerState, obj: LobbyObject) -> None:
+        triggered.append((player.position, obj.identifier))
+
+    player = PlayerState(position=(0, 0), size=(1, 1))
+    console = LobbyObject(
+        identifier="console",
+        position=(0, 0),
+        size=(1, 1),
+        interaction=Interaction(callback=callback),
+    )
+    engine = GameEngine([console], player)
+
+    fired = engine.handle_input(["SPACE"])
+
+    assert triggered == [((0, 0), "console")]
+    assert fired == [console.interaction]
+
+
+def test_interaction_does_not_trigger_without_overlap_or_keypress():
+    fired = []
+
+    def callback(_: PlayerState, __: LobbyObject) -> None:
+        fired.append(True)
+
+    player = PlayerState(position=(5, 5), size=(1, 1))
+    trophy = LobbyObject(
+        identifier="trophy",
+        position=(0, 0),
+        size=(1, 1),
+        interaction=Interaction(callback=callback),
+    )
+    engine = GameEngine([trophy], player)
+
+    assert engine.handle_input(["space"]) == []
+    assert fired == []
+
+    # Now overlap but without pressing the key.
+    player.position = (0, 0)
+    assert engine.handle_input([]) == []
+    assert fired == []
+
+
+def test_interaction_only_triggers_once_when_configured():
+    count = 0
+
+    def callback(_: PlayerState, __: LobbyObject) -> None:
+        nonlocal count
+        count += 1
+
+    player = PlayerState(position=(0, 0), size=(1, 1))
+    poster = LobbyObject(
+        identifier="poster",
+        position=(0, 0),
+        size=(1, 1),
+        interaction=Interaction(callback=callback, once=True),
+    )
+    engine = GameEngine([poster], player)
+
+    assert engine.handle_input(["space"]) == [poster.interaction]
+    assert count == 1
+
+    # Subsequent presses should not trigger the callback again.
+    assert engine.handle_input(["space"]) == []
+    assert count == 1
+
+
+def test_player_movement_blocked_by_solid_objects():
+    player = PlayerState(position=(0, 0), size=(1, 1))
+    wall = LobbyObject(
+        identifier="wall",
+        position=(1, 0),
+        size=(1, 1),
+        blocking=True,
+    )
+    engine = GameEngine([wall], player)
+
+    # Attempting to move into the wall should fail.
+    moved = engine.move_player(1, 0)
+    assert moved is False
+    assert player.position == (0, 0)
+
+    # Moving in a free direction should succeed.
+    moved = engine.move_player(0, 1)
+    assert moved is True
+    assert player.position == (0, 1)


### PR DESCRIPTION
## Summary
- add lobby interaction, object, and player dataclasses to describe hitboxes and callbacks
- implement a simple game engine that blocks movement against solid hitboxes and fires interactions on the space key
- cover interaction and collision behaviour with unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d17e53bd7483249a6627f2ec1a5546