### PR TITLE
Fix asset loading paths for static hosting

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,9 +4,14 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Astrocat Lobby</title>
+    <link
+      rel="icon"
+      type="image/svg+xml"
+      href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='12' ry='12' fill='%231a1a28'/%3E%3Cpath d='M20 46c0-6 6-8 12-8s12 2 12 8' fill='%23f5deb3'/%3E%3Ccircle cx='24' cy='28' r='8' fill='%23ffb6c1'/%3E%3Ccircle cx='40' cy='28' r='8' fill='%23ffb6c1'/%3E%3Ccircle cx='24' cy='26' r='2' fill='%231a1a28'/%3E%3Ccircle cx='40' cy='26' r='2' fill='%231a1a28'/%3E%3Cpath d='M16 20l4-6h4l-2 6zm28 0l-4-6h-4l2 6z' fill='%23555'/%3E%3C/svg%3E"
+    />
   </head>
   <body>
     <div id="app"></div>
-    <script type="module" src="/src/main.ts"></script>
+    <script type="module" src="./src/main.ts"></script>
   </body>
 </html>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from "vite";
 
 export default defineConfig({
+  base: "./",
   build: {
     target: "esnext"
   }


### PR DESCRIPTION
## Summary
- ensure the main module is loaded via a relative path so it can be served from subdirectories
- embed a small SVG favicon directly in the HTML to avoid 404 icon requests
- configure Vite to emit relative asset URLs for static hosting

## Testing
- npm run build *(fails: registry access to @types/node is forbidden in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1928acfe08324bcf76ece2c334471