### PR TITLE
Fix TypeScript MIME type for Vite server

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,5 +4,15 @@ export default defineConfig({
   base: "./",
   build: {
     target: "esnext"
+  },
+  server: {
+    mimeTypes: {
+      "application/javascript": ["ts"]
+    }
+  },
+  preview: {
+    mimeTypes: {
+      "application/javascript": ["ts"]
+    }
   }
 });


### PR DESCRIPTION
## Summary
- configure the dev and preview servers to serve `.ts` files with an `application/javascript` MIME type so module scripts load correctly under strict checks

## Testing
- not run (npm install fails in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d196b6fbe48324b5088953c1fb2eed