### PR TITLE
Switch client entry to JavaScript to avoid MIME issues

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,6 @@
   </head>
   <body>
     <div id="app"></div>
-    <script type="module" src="./src/main.ts"></script>
+    <script type="module" src="./src/main.js"></script>
   </body>
 </html>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,15 +4,5 @@ export default defineConfig({
   base: "./",
   build: {
     target: "esnext"
-  },
-  server: {
-    mimeTypes: {
-      "application/javascript": ["ts"]
-    }
-  },
-  preview: {
-    mimeTypes: {
-      "application/javascript": ["ts"]
-    }
   }
 });


### PR DESCRIPTION
## Summary
- convert the Phaser game bootstrap file from TypeScript to vanilla JavaScript with JSDoc typing so browsers receive a proper JavaScript MIME type
- update index.html to load the new JavaScript entry point when the page is opened outside of Vite
- simplify the Vite configuration now that custom TypeScript MIME overrides are unnecessary

## Testing
- npm install *(fails: registry returned 403 when fetching @types/node)*

------
https://chatgpt.com/codex/tasks/task_e_68d198ed81648324936e58832b26acaf