### PR TITLE
Add dynamic Phaser loader with CDN fallback

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,29 @@
-import Phaser from "phaser";
 import "./style.css";
+
+async function loadPhaserModule() {
+  try {
+    const phaserModule = await import("phaser");
+    return resolvePhaserModule(phaserModule);
+  } catch (error) {
+    console.warn(
+      "Unable to load Phaser from node_modules, falling back to CDN distribution.",
+      error
+    );
+    const cdnModule = await import(
+      "https://cdn.jsdelivr.net/npm/phaser@3.70.0/dist/phaser.esm.js"
+    );
+    return resolvePhaserModule(cdnModule);
+  }
+}
+
+/**
+ * @param {any} module
+ */
+function resolvePhaserModule(module) {
+  return module?.default ?? module?.Phaser ?? module;
+}
+
+const Phaser = await loadPhaserModule();
 
 /**
  * @typedef {"hp" | "mp" | "exp"} StatKey


### PR DESCRIPTION
## Summary
- load Phaser dynamically and fall back to a CDN build when the local module is unavailable

## Testing
- not run (npm install failed: received 403 Forbidden when downloading @types/node)


------
https://chatgpt.com/codex/tasks/task_e_68d1a0a4d35c832494ee6af20e1a438a