### PR TITLE
Replace Phaser scene with canvas lobby

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,7 @@
     "preview": "vite preview",
     "lint": "tsc --noEmit"
   },
-  "dependencies": {
-    "phaser": "^3.70.0"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@types/node": "^20.11.30",
     "typescript": "^5.4.5",

--- a/src/main.js
+++ b/src/main.js
@@ -1,812 +1,629 @@
 import "./style.css";
 
-async function loadPhaserModule() {
-  try {
-    const phaserModule = await import("phaser");
-    return resolvePhaserModule(phaserModule);
-  } catch (error) {
-    console.warn(
-      "Unable to load Phaser from node_modules, falling back to CDN distribution.",
-      error
-    );
-    const cdnModule = await import(
-      "https://cdn.jsdelivr.net/npm/phaser@3.70.0/dist/phaser.esm.js"
-    );
-    return resolvePhaserModule(cdnModule);
-  }
+const app = document.querySelector("#app");
+if (!app) {
+  throw new Error("Missing #app container");
 }
 
-/**
- * @param {any} module
- */
-function resolvePhaserModule(module) {
-  return module?.default ?? module?.Phaser ?? module;
-}
-
-const Phaser = await loadPhaserModule();
-
-/**
- * @typedef {"hp" | "mp" | "exp"} StatKey
- */
-
-/**
- * @typedef {Object} PlayerStats
- * @property {string} name
- * @property {number} level
- * @property {string} rank
- * @property {number} exp
- * @property {number} maxExp
- * @property {number} hp
- * @property {number} maxHp
- * @property {number} mp
- * @property {number} maxMp
- * @property {number} hairColor
- * @property {number} skinColor
- * @property {number} shirtColor
- */
-
-/**
- * @typedef {Object} StatBar
- * @property {Phaser.GameObjects.Rectangle} fill
- * @property {Phaser.GameObjects.Text} valueLabel
- * @property {number} maxWidth
- */
-
-class BootScene extends Phaser.Scene {
-  constructor() {
-    super({ key: "BootScene" });
-  }
-
-  preload() {
-    this.createTextures();
-  }
-
-  createTextures() {
-    const graphics = this.make.graphics({ x: 0, y: 0, add: false });
-
-    graphics.fillStyle(0xffb6c1, 1);
-    graphics.fillRoundedRect(0, 0, 24, 32, 4);
-    graphics.fillStyle(0x8b4513, 1);
-    graphics.fillCircle(12, 8, 6);
-    graphics.fillStyle(0x000000, 1);
-    graphics.fillCircle(8, 6, 1);
-    graphics.fillCircle(16, 6, 1);
-    graphics.generateTexture("player", 24, 32);
-    graphics.clear();
-
-    graphics.fillStyle(0x228b22, 1);
-    graphics.fillRect(0, 0, 64, 32);
-    graphics.generateTexture("ground", 64, 32);
-    graphics.clear();
-
-    graphics.fillStyle(0x8b4513, 1);
-    graphics.fillRect(14, 16, 4, 16);
-    graphics.fillStyle(0x228b22, 1);
-    graphics.fillCircle(16, 12, 12);
-    graphics.generateTexture("tree", 32, 32);
-    graphics.clear();
-
-    graphics.fillStyle(0x8b4513, 1);
-    graphics.fillRoundedRect(0, 0, 24, 16, 2);
-    graphics.fillStyle(0xffd700, 1);
-    graphics.fillRect(10, 6, 4, 2);
-    graphics.generateTexture("chest", 24, 16);
-    graphics.clear();
-
-    graphics.fillStyle(0x9370db, 1);
-    graphics.fillTriangle(8, 0, 0, 16, 16, 16);
-    graphics.generateTexture("crystal", 16, 16);
-    graphics.clear();
-
-    graphics.fillStyle(0x87ceeb, 1);
-    graphics.fillRect(0, 0, 800, 400);
-    graphics.fillStyle(0x98fb98, 1);
-    for (let i = 0; i < 10; i += 1) {
-      graphics.fillCircle(i * 80 + 40, 350, 30);
-    }
-    graphics.generateTexture("background", 800, 400);
-    graphics.clear();
-
-    graphics.destroy();
-  }
-
-  create() {
-    this.scene.start("GameScene");
-  }
-}
-
-class GameScene extends Phaser.Scene {
-  /** @type {PlayerStats} */
-  playerData = {
-    name: "PixelHero",
-    level: 15,
-    rank: "Adventurer",
-    exp: 750,
-    maxExp: 1000,
-    hp: 85,
-    maxHp: 100,
-    mp: 40,
-    maxMp: 60,
-    hairColor: 0x8b4513,
-    skinColor: 0xffb6c1,
-    shirtColor: 0x4169e1
-  };
-
-  isCustomizing = false;
-
-  gameAreaWidth = 0;
-
-  /** @type {Phaser.Physics.Arcade.StaticGroup | undefined} */
-  platforms;
-
-  /** @type {Phaser.Physics.Arcade.Sprite | undefined} */
-  player;
-
-  /** @type {Phaser.Physics.Arcade.StaticGroup | undefined} */
-  interactables;
-
-  /** @type {Phaser.GameObjects.Text | undefined} */
-  interactionText;
-
-  /** @type {Phaser.Types.Input.Keyboard.CursorKeys | undefined} */
-  cursors;
-
-  /**
-   * @type {{
-   *   W?: Phaser.Input.Keyboard.Key;
-   *   A?: Phaser.Input.Keyboard.Key;
-   *   S?: Phaser.Input.Keyboard.Key;
-   *   D?: Phaser.Input.Keyboard.Key;
-   * }}
-   */
-  wasd = {};
-
-  /** @type {Phaser.Input.Keyboard.Key | undefined} */
-  interactKey;
-
-  /** @type {Phaser.Physics.Arcade.Sprite | undefined} */
-  nearObject;
-
-  uiStartX = 0;
-
-  /** @type {Phaser.GameObjects.Rectangle | undefined} */
-  uiRect;
-
-  /** @type {Phaser.GameObjects.Rectangle | undefined} */
-  charPortraitFrame;
-
-  /** @type {Phaser.GameObjects.Graphics | undefined} */
-  portraitGraphics;
-
-  /** @type {Phaser.GameObjects.Text | undefined} */
-  nameText;
-
-  /** @type {Phaser.GameObjects.Text | undefined} */
-  levelText;
-
-  /** @type {Phaser.GameObjects.Text | undefined} */
-  rankText;
-
-  /** @type {Record<StatKey, StatBar> | undefined} */
-  statBars;
-
-  /** @type {Phaser.GameObjects.Rectangle | undefined} */
-  customButton;
-
-  /** @type {Phaser.GameObjects.Text | undefined} */
-  customButtonText;
-
-  /** @type {Phaser.GameObjects.Container | undefined} */
-  customPanel;
-
-  /** @type {Phaser.GameObjects.Rectangle[]} */
-  hairButtons = [];
-
-  /** @type {Phaser.GameObjects.Rectangle[]} */
-  skinButtons = [];
-
-  /** @type {Phaser.GameObjects.Rectangle[]} */
-  shirtButtons = [];
-
-  constructor() {
-    super({ key: "GameScene" });
-  }
-
-  create() {
-    this.setupGameArea();
-    this.setupUI();
-    this.setupPlayer();
-    this.setupInteractables();
-    this.setupControls();
-    this.setupCamera();
-    this.updateCharacterAppearance();
-    this.updateUI();
-  }
-
-  getScaleWidth() {
-    const width = this.scale.gameSize.width;
-    if (width > 0) {
-      return width;
-    }
-
-    const configWidth = this.game.config.width;
-    if (typeof configWidth === "number" && configWidth > 0) {
-      return configWidth;
-    }
-
-    return window.innerWidth;
-  }
-
-  getScaleHeight() {
-    const height = this.scale.gameSize.height;
-    if (height > 0) {
-      return height;
-    }
-
-    const configHeight = this.game.config.height;
-    if (typeof configHeight === "number" && configHeight > 0) {
-      return configHeight;
-    }
-
-    return window.innerHeight;
-  }
-
-  setupGameArea() {
-    const scaleWidth = this.getScaleWidth();
-    const scaleHeight = this.getScaleHeight();
-
-    this.gameAreaWidth = Math.max(960, Math.floor(scaleWidth * 0.65));
-
-    const bg = this.add.image(this.gameAreaWidth / 2, scaleHeight / 2, "background");
-    bg.setDisplaySize(this.gameAreaWidth, scaleHeight);
-
-    this.physics.world.setBounds(0, 0, this.gameAreaWidth + 400, scaleHeight);
-
-    this.platforms = this.physics.add.staticGroup();
-    for (let x = -64; x <= this.gameAreaWidth + 256; x += 64) {
-      const ground = this.platforms.create(x, scaleHeight - 50, "ground");
-      ground.setOrigin(0, 0);
-      ground.refreshBody();
-    }
-
-    for (let i = 0; i < 5; i += 1) {
-      const platform = this.platforms.create(200 + i * 150, scaleHeight - 180 - i * 30, "ground");
-      platform.setDisplaySize(100, 20);
-      platform.refreshBody();
-    }
-  }
-
-  setupUI() {
-    this.uiStartX = Math.floor(this.gameAreaWidth) + 20;
-
-    const scaleWidth = this.getScaleWidth();
-    const scaleHeight = this.getScaleHeight();
-    const uiWidth = Math.max(260, scaleWidth - this.uiStartX - 20);
-
-    this.uiRect = this.add.rectangle(this.uiStartX, 0, uiWidth, scaleHeight, 0x2c2c54, 0.9);
-    this.uiRect.setOrigin(0, 0);
-    this.uiRect.setScrollFactor(0);
-
-    this.charPortraitFrame = this.add.rectangle(this.uiStartX + uiWidth / 2, 90, 160, 160, 0x1c1c3a, 0.9);
-    this.charPortraitFrame.setStrokeStyle(3, 0xffd700);
-    this.charPortraitFrame.setScrollFactor(0);
-
-    this.portraitGraphics = this.add.graphics();
-    this.portraitGraphics.setScrollFactor(0);
-    this.portraitGraphics.setDepth(1);
-
-    const header = this.add.text(this.uiStartX + 20, 190, "Character Info", {
-      fontSize: "20px",
-      color: "#FFD700",
-      fontFamily: "Arial"
-    });
-    header.setScrollFactor(0);
-
-    this.nameText = this.add.text(this.uiStartX + 20, 220, "", {
-      fontSize: "16px",
-      color: "#FFFFFF"
-    });
-    this.nameText.setScrollFactor(0);
-
-    this.levelText = this.add.text(this.uiStartX + 20, 248, "", {
-      fontSize: "16px",
-      color: "#FFFFFF"
-    });
-    this.levelText.setScrollFactor(0);
-
-    this.rankText = this.add.text(this.uiStartX + 20, 276, "", {
-      fontSize: "16px",
-      color: "#FFFFFF"
-    });
-    this.rankText.setScrollFactor(0);
-
-    const safeStatBars = /** @type {Record<StatKey, StatBar>} */ ({
-      hp: this.createStatBar(this.uiStartX + 20, 320, "HP", this.playerData.hp, this.playerData.maxHp, 0xff0000),
-      mp: this.createStatBar(this.uiStartX + 20, 360, "MP", this.playerData.mp, this.playerData.maxMp, 0x0000ff),
-      exp: this.createStatBar(this.uiStartX + 20, 400, "EXP", this.playerData.exp, this.playerData.maxExp, 0x00ff00)
-    });
-    this.statBars = safeStatBars;
-
-    this.customButton = this.add.rectangle(this.uiStartX + uiWidth / 2, 450, 140, 44, 0x4169e1, 1);
-    this.customButton.setStrokeStyle(2, 0xffffff);
-    this.customButton.setScrollFactor(0);
-    this.customButton.setInteractive({ useHandCursor: true });
-    this.customButton.on("pointerdown", () => this.toggleCustomization());
-
-    this.customButtonText = this.add.text(this.customButton.x, this.customButton.y, "Customize", {
-      fontSize: "16px",
-      color: "#FFFFFF"
-    });
-    this.customButtonText.setOrigin(0.5);
-    this.customButtonText.setScrollFactor(0);
-
-    this.setupCustomizationPanel(uiWidth);
-  }
-
-  /**
-   * @param {number} x
-   * @param {number} y
-   * @param {string} label
-   * @param {number} current
-   * @param {number} max
-   * @param {number} color
-   * @returns {StatBar}
-   */
-  createStatBar(x, y, label, current, max, color) {
-    const labelText = this.add.text(x, y - 18, label, {
-      fontSize: "14px",
-      color: "#FFFFFF"
-    });
-    labelText.setScrollFactor(0);
-
-    const barBg = this.add.rectangle(x, y, 160, 16, 0x333333, 1);
-    barBg.setOrigin(0, 0);
-    barBg.setScrollFactor(0);
-
-    const safeMax = max === 0 ? 1 : max;
-    const barFill = this.add.rectangle(x + 2, y + 2, (current / safeMax) * 156, 12, color, 1);
-    barFill.setOrigin(0, 0);
-    barFill.setScrollFactor(0);
-
-    const valueLabel = this.add.text(x + 170, y - 1, `${current}/${max}`, {
-      fontSize: "12px",
-      color: "#FFFFFF"
-    });
-    valueLabel.setScrollFactor(0);
-
-    return {
-      fill: barFill,
-      valueLabel,
-      maxWidth: 156
-    };
-  }
-
-  setupCustomizationPanel(uiWidth) {
-    this.customPanel = this.add.container(0, 0);
-    this.customPanel.setScrollFactor(0);
-    this.customPanel.setDepth(2);
-
-    const panelBg = this.add.rectangle(this.uiStartX + 20, 500, uiWidth - 40, 200, 0x1c1c3a, 0.95);
-    panelBg.setOrigin(0, 0);
-    panelBg.setStrokeStyle(2, 0xffd700);
-    panelBg.setScrollFactor(0);
-    this.customPanel.add(panelBg);
-
-    const hairLabel = this.add.text(this.uiStartX + 30, 520, "Hair Color", {
-      fontSize: "14px",
-      color: "#FFFFFF"
-    });
-    hairLabel.setScrollFactor(0);
-    this.customPanel.add(hairLabel);
-
-    const hairColors = [0x8b4513, 0x000000, 0xffd700, 0xff6347];
-    hairColors.forEach((color, index) => {
-      const colorBtn = this.add.rectangle(this.uiStartX + 30 + index * 40, 545, 28, 28, color, 1);
-      colorBtn.setStrokeStyle(2, 0xffffff);
-      colorBtn.setScrollFactor(0);
-      colorBtn.setInteractive({ useHandCursor: true });
-      colorBtn.on("pointerdown", () => this.changeHairColor(color));
-      this.customPanel.add(colorBtn);
-      this.hairButtons.push(colorBtn);
-    });
-
-    const skinLabel = this.add.text(this.uiStartX + 30, 585, "Skin Tone", {
-      fontSize: "14px",
-      color: "#FFFFFF"
-    });
-    skinLabel.setScrollFactor(0);
-    this.customPanel.add(skinLabel);
-
-    const skinColors = [0xffb6c1, 0xf5deb3, 0xdeb887, 0x8b4513];
-    skinColors.forEach((color, index) => {
-      const colorBtn = this.add.rectangle(this.uiStartX + 30 + index * 40, 610, 28, 28, color, 1);
-      colorBtn.setStrokeStyle(2, 0xffffff);
-      colorBtn.setScrollFactor(0);
-      colorBtn.setInteractive({ useHandCursor: true });
-      colorBtn.on("pointerdown", () => this.changeSkinColor(color));
-      this.customPanel.add(colorBtn);
-      this.skinButtons.push(colorBtn);
-    });
-
-    const shirtLabel = this.add.text(this.uiStartX + 30, 650, "Shirt Color", {
-      fontSize: "14px",
-      color: "#FFFFFF"
-    });
-    shirtLabel.setScrollFactor(0);
-    this.customPanel.add(shirtLabel);
-
-    const shirtColors = [0x4169e1, 0xff0000, 0x32cd32, 0x800080];
-    shirtColors.forEach((color, index) => {
-      const colorBtn = this.add.rectangle(this.uiStartX + 30 + index * 40, 675, 28, 28, color, 1);
-      colorBtn.setStrokeStyle(2, 0xffffff);
-      colorBtn.setScrollFactor(0);
-      colorBtn.setInteractive({ useHandCursor: true });
-      colorBtn.on("pointerdown", () => this.changeShirtColor(color));
-      this.customPanel.add(colorBtn);
-      this.shirtButtons.push(colorBtn);
-    });
-
-    this.customPanel.setVisible(false);
-    this.customPanel.list.forEach((child) => {
-      child.active = false;
-    });
-
-    this.updateColorSelection(this.hairButtons, this.playerData.hairColor);
-    this.updateColorSelection(this.skinButtons, this.playerData.skinColor);
-    this.updateColorSelection(this.shirtButtons, this.playerData.shirtColor);
-  }
-
-  setupPlayer() {
-    const scaleHeight = this.getScaleHeight();
-    this.player = this.physics.add.sprite(120, scaleHeight - 120, "player");
-    this.player.setBounce(0.2);
-    this.player.setCollideWorldBounds(true);
-    this.player.setDepth(2);
-    this.physics.add.collider(this.player, this.platforms);
-  }
-
-  setupInteractables() {
-    this.interactables = this.physics.add.staticGroup();
-
-    const groundY = this.getScaleHeight() - 50;
-    /** @type {{ x: number; y: number; key: string }[]} */
-    const items = [
-      { x: 280, y: groundY, key: "tree" },
-      { x: 520, y: groundY, key: "chest" },
-      { x: 760, y: groundY, key: "crystal" },
-      { x: 1020, y: groundY, key: "tree" },
-      { x: 1260, y: groundY, key: "chest" }
-    ];
-
-    items.forEach(({ x, y, key }) => {
-      const sprite = /** @type {Phaser.Physics.Arcade.Sprite} */ (this.interactables.create(x, y, key));
-      sprite.setOrigin(0.5, 1);
-      sprite.refreshBody();
-      sprite.setDepth(1);
-    });
-
-    this.physics.add.collider(this.interactables, this.platforms);
-
-    this.physics.add.overlap(
-      this.player,
-      this.interactables,
-      (_player, object) => {
-        this.handleInteraction(/** @type {Phaser.Physics.Arcade.Sprite} */ (object));
-      },
-      undefined,
-      this
-    );
-
-    this.interactionText = this.add.text(0, 0, "", {
-      fontSize: "16px",
-      color: "#FFFF00",
-      backgroundColor: "#000000",
-      padding: { x: 6, y: 4 }
-    });
-    this.interactionText.setVisible(false);
-    this.interactionText.setDepth(5);
-  }
-
-  setupControls() {
-    this.cursors = this.input.keyboard.createCursorKeys();
-    this.wasd = /** @type {{ W: Phaser.Input.Keyboard.Key; A: Phaser.Input.Keyboard.Key; S: Phaser.Input.Keyboard.Key; D: Phaser.Input.Keyboard.Key; }} */ (
-      this.input.keyboard.addKeys({
-        W: Phaser.Input.Keyboard.KeyCodes.W,
-        A: Phaser.Input.Keyboard.KeyCodes.A,
-        S: Phaser.Input.Keyboard.KeyCodes.S,
-        D: Phaser.Input.Keyboard.KeyCodes.D
-      })
-    );
-
-    this.interactKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.SPACE);
-    this.interactKey.on("down", () => {
-      if (this.nearObject) {
-        this.interactWithObject(this.nearObject);
-      }
-    });
-  }
-
-  setupCamera() {
-    this.cameras.main.setBounds(0, 0, this.gameAreaWidth + 400, this.getScaleHeight());
-    this.cameras.main.startFollow(this.player, true, 0.08, 0.08);
-    this.cameras.main.setDeadzone(120, 80);
-  }
-
-  toggleCustomization() {
-    this.isCustomizing = !this.isCustomizing;
-    this.customPanel.setVisible(this.isCustomizing);
-    this.customPanel.list.forEach((child) => {
-      child.active = this.isCustomizing;
-    });
-    this.customButtonText.setText(this.isCustomizing ? "Close" : "Customize");
-  }
-
-  changeHairColor(color) {
-    if (this.playerData.hairColor === color) {
-      return;
-    }
-    this.playerData.hairColor = color;
-    this.updateColorSelection(this.hairButtons, color);
-    this.updateCharacterAppearance();
-  }
-
-  changeSkinColor(color) {
-    if (this.playerData.skinColor === color) {
-      return;
-    }
-    this.playerData.skinColor = color;
-    this.updateColorSelection(this.skinButtons, color);
-    this.updateCharacterAppearance();
-  }
-
-  changeShirtColor(color) {
-    if (this.playerData.shirtColor === color) {
-      return;
-    }
-    this.playerData.shirtColor = color;
-    this.updateColorSelection(this.shirtButtons, color);
-    this.updateCharacterAppearance();
-  }
-
-  /**
-   * @param {Phaser.GameObjects.Rectangle[]} buttons
-   * @param {number} selectedColor
-   */
-  updateColorSelection(buttons, selectedColor) {
-    buttons.forEach((button) => {
-      const strokeColor = button.fillColor === selectedColor ? 0xffd700 : 0xffffff;
-      button.setStrokeStyle(2, strokeColor);
-    });
-  }
-
-  updateCharacterAppearance() {
-    this.refreshPlayerTexture();
-    this.drawPortrait();
-  }
-
-  refreshPlayerTexture() {
-    const textureKey = "player-custom";
-    if (this.textures.exists(textureKey)) {
-      this.textures.remove(textureKey);
-    }
-
-    const graphics = this.make.graphics({ x: 0, y: 0, add: false });
-
-    graphics.fillStyle(this.playerData.shirtColor, 1);
-    graphics.fillRoundedRect(4, 16, 16, 14, 4);
-
-    graphics.fillStyle(this.playerData.skinColor, 1);
-    graphics.fillRoundedRect(6, 6, 12, 12, 6);
-
-    graphics.fillStyle(this.playerData.hairColor, 1);
-    graphics.fillCircle(12, 6, 8);
-
-    graphics.fillStyle(0x000000, 1);
-    graphics.fillCircle(9, 12, 1.2);
-    graphics.fillCircle(15, 12, 1.2);
-
-    graphics.generateTexture(textureKey, 24, 32);
-    graphics.destroy();
-
-    this.player.setTexture(textureKey);
-    this.player.setSize(24, 32);
-    this.player.setOffset(0, 0);
-  }
-
-  drawPortrait() {
-    const centerX = this.uiStartX + this.uiRect.width / 2;
-    const topY = 40;
-
-    this.portraitGraphics.clear();
-
-    this.portraitGraphics.fillStyle(0x252544, 1);
-    this.portraitGraphics.fillRoundedRect(centerX - 70, topY - 10, 140, 160, 18);
-
-    this.portraitGraphics.fillStyle(this.playerData.shirtColor, 1);
-    this.portraitGraphics.fillRoundedRect(centerX - 60, topY + 80, 120, 70, 24);
-
-    this.portraitGraphics.fillStyle(this.playerData.skinColor, 1);
-    this.portraitGraphics.fillCircle(centerX, topY + 70, 45);
-
-    this.portraitGraphics.fillStyle(this.playerData.hairColor, 1);
-    this.portraitGraphics.fillCircle(centerX, topY + 30, 55);
-    this.portraitGraphics.fillCircle(centerX - 34, topY + 56, 18);
-    this.portraitGraphics.fillCircle(centerX + 34, topY + 56, 18);
-
-    this.portraitGraphics.fillStyle(0x000000, 1);
-    this.portraitGraphics.fillCircle(centerX - 18, topY + 60, 6);
-    this.portraitGraphics.fillCircle(centerX + 18, topY + 60, 6);
-
-    this.portraitGraphics.fillStyle(0xffa07a, 1);
-    this.portraitGraphics.fillEllipse(centerX, topY + 92, 30, 12);
-  }
-
-  /**
-   * @param {Phaser.Physics.Arcade.Sprite} object
-   */
-  handleInteraction(object) {
-    if (this.nearObject === object) {
-      return;
-    }
-
-    this.nearObject = object;
-    this.interactionText.setText("Press SPACE");
-    this.interactionText.setVisible(true);
-    this.interactionText.setPosition(
-      object.x - object.displayWidth * 0.5,
-      object.y - object.displayHeight - 16
-    );
-  }
-
-  /**
-   * @param {Phaser.Physics.Arcade.Sprite} object
-   */
-  interactWithObject(object) {
-    let message = "";
-    const objectType = object.texture.key;
-
-    switch (objectType) {
-      case "tree":
-        message = "You found some berries! +5 HP";
-        this.playerData.hp = Math.min(this.playerData.hp + 5, this.playerData.maxHp);
-        break;
-      case "chest":
-        message = "Treasure! +50 EXP";
-        this.playerData.exp = Math.min(this.playerData.exp + 50, this.playerData.maxExp);
-        if (this.playerData.exp >= this.playerData.maxExp) {
-          this.levelUp();
-        }
-        break;
-      case "crystal":
-        message = "Magic crystal! +10 MP";
-        this.playerData.mp = Math.min(this.playerData.mp + 10, this.playerData.maxMp);
-        break;
-      default:
-        break;
-    }
-
-    this.showMessage(message);
-    object.destroy();
-    this.nearObject = undefined;
-    this.interactionText.setVisible(false);
-    this.updateUI();
-  }
-
-  levelUp() {
-    this.playerData.level += 1;
-    this.playerData.rank = this.playerData.level >= 20 ? "Elite" : "Adventurer";
-    this.playerData.exp = 0;
-    this.playerData.maxExp += 200;
-    this.playerData.maxHp += 10;
-    this.playerData.maxMp += 5;
-    this.playerData.hp = Math.min(this.playerData.hp + 10, this.playerData.maxHp);
-    this.playerData.mp = Math.min(this.playerData.mp + 5, this.playerData.maxMp);
-    this.showMessage(`Level Up! Now level ${this.playerData.level}!`);
-  }
-
-  showMessage(text) {
-    const message = this.add.text(this.player.x, this.player.y - 70, text, {
-      fontSize: "14px",
-      color: "#FFFF00",
-      backgroundColor: "#000000",
-      padding: { x: 6, y: 4 }
-    });
-    message.setOrigin(0.5);
-    message.setDepth(5);
-
-    this.tweens.add({
-      targets: message,
-      y: message.y - 40,
-      alpha: 0,
-      duration: 2200,
-      ease: "Sine.easeIn",
-      onComplete: () => message.destroy()
-    });
-  }
-
-  update() {
-    if (!this.player) {
-      return;
-    }
-
-    const body = /** @type {Phaser.Physics.Arcade.Body} */ (this.player.body);
-    const speed = 200;
-
-    this.player.setVelocityX(0);
-
-    if (this.cursors.left.isDown || this.wasd.A.isDown) {
-      this.player.setVelocityX(-speed);
-      this.player.setFlipX(true);
-    } else if (this.cursors.right.isDown || this.wasd.D.isDown) {
-      this.player.setVelocityX(speed);
-      this.player.setFlipX(false);
-    }
-
-    if ((this.cursors.up.isDown || this.wasd.W.isDown) && body.blocked.down) {
-      this.player.setVelocityY(-330);
-    }
-
-    if (this.nearObject) {
-      if (!this.nearObject.active || !this.physics.overlap(this.player, this.nearObject)) {
-        this.nearObject = undefined;
-        this.interactionText.setVisible(false);
-      } else {
-        this.interactionText.setPosition(
-          this.nearObject.x - this.nearObject.displayWidth * 0.5,
-          this.nearObject.y - this.nearObject.displayHeight - 16
-        );
-      }
-    }
-
-    this.updateUI();
-  }
-
-  updateUI() {
-    this.nameText.setText(`Name: ${this.playerData.name}`);
-    this.levelText.setText(`Level: ${this.playerData.level}`);
-    this.rankText.setText(`Rank: ${this.playerData.rank}`);
-
-    this.updateStatBar("hp", this.playerData.hp, this.playerData.maxHp);
-    this.updateStatBar("mp", this.playerData.mp, this.playerData.maxMp);
-    this.updateStatBar("exp", this.playerData.exp, this.playerData.maxExp);
-  }
-
-  /**
-   * @param {StatKey} stat
-   * @param {number} current
-   * @param {number} max
-   */
-  updateStatBar(stat, current, max) {
-    const bar = this.statBars[stat];
-    const ratio = Phaser.Math.Clamp(max === 0 ? 0 : current / max, 0, 1);
-    bar.fill.displayWidth = ratio * bar.maxWidth;
-    bar.valueLabel.setText(`${current}/${max}`);
-  }
-}
-
-/** @type {Phaser.Types.Core.GameConfig} */
-const config = {
-  type: Phaser.AUTO,
-  parent: "app",
-  backgroundColor: "#1A1A28",
-  scale: {
-    mode: Phaser.Scale.RESIZE,
-    autoCenter: Phaser.Scale.CENTER_BOTH,
-    width: window.innerWidth,
-    height: window.innerHeight
-  },
-  physics: {
-    default: "arcade",
-    arcade: {
-      gravity: { y: 300 },
-      debug: false
-    }
-  },
-  scene: [BootScene, GameScene]
+const playerStats = {
+  name: "PixelHero",
+  level: 15,
+  rank: "Adventurer",
+  exp: 750,
+  maxExp: 1000,
+  hp: 85,
+  maxHp: 100,
+  mp: 40,
+  maxMp: 60
 };
 
-export const game = new Phaser.Game(config);
+const defaultMessage = "Use A/D or ←/→ to move. Press Space to jump.";
+let messageTimerId = 0;
 
-window.addEventListener("resize", () => {
-  game.scale.resize(window.innerWidth, window.innerHeight);
+const ui = createInterface(playerStats);
+app.innerHTML = "";
+app.append(ui.root);
+
+const canvas = document.createElement("canvas");
+canvas.width = 960;
+canvas.height = 540;
+canvas.className = "game-canvas";
+ui.canvasWrapper.append(canvas);
+
+const ctx = canvas.getContext("2d");
+if (!ctx) {
+  throw new Error("Unable to acquire 2D context");
+}
+
+const groundY = canvas.height - 96;
+const stars = Array.from({ length: 48 }, () => ({
+  x: Math.random() * canvas.width,
+  y: Math.random() * (groundY - 120),
+  size: Math.random() * 2 + 0.5,
+  twinkle: Math.random() * Math.PI * 2
+}));
+
+const player = {
+  x: canvas.width / 2 - 16,
+  y: groundY - 48,
+  width: 32,
+  height: 48,
+  vx: 0,
+  vy: 0,
+  direction: 1,
+  onGround: false
+};
+
+const platforms = [
+  { x: 140, y: groundY - 120, width: 160, height: 18 },
+  { x: 468, y: groundY - 180, width: 200, height: 18 },
+  { x: 724, y: groundY - 80, width: 150, height: 18 }
+];
+
+const crystals = [
+  { x: 220, y: groundY - 36, radius: 12, collected: false },
+  { x: 520, y: groundY - 220, radius: 12, collected: false },
+  { x: 780, y: groundY - 116, radius: 12, collected: false },
+  { x: 360, y: groundY - 156, radius: 12, collected: false },
+  { x: 640, y: groundY - 36, radius: 12, collected: false }
+];
+
+const interactables = [
+  {
+    type: "chest",
+    label: "Treasure Chest",
+    x: 84,
+    y: groundY - 46,
+    width: 44,
+    height: 36,
+    opened: false
+  },
+  {
+    type: "fountain",
+    label: "Mana Fountain",
+    x: 840,
+    y: groundY - 68,
+    width: 48,
+    height: 52,
+    charges: 2
+  },
+  {
+    type: "npc",
+    name: "Nova",
+    label: "Nova the Guide",
+    x: 320,
+    y: groundY - 60,
+    width: 42,
+    height: 54,
+    dialogue: [
+      "Welcome to the Astrocat Lobby!",
+      "Collect the floating crystals to charge the portal.",
+      "Need a boost? Try the chest or the fountain nearby."
+    ],
+    lineIndex: 0
+  }
+];
+
+const keys = new Set();
+const justPressed = new Set();
+
+window.addEventListener("keydown", (event) => {
+  if (!event.repeat) {
+    justPressed.add(event.code);
+  }
+  keys.add(event.code);
 });
+
+window.addEventListener("keyup", (event) => {
+  keys.delete(event.code);
+});
+
+showMessage(defaultMessage, 0);
+ui.updateCrystals(0, crystals.length);
+ui.refresh(playerStats);
+
+let lastTimestamp = performance.now();
+requestAnimationFrame(loop);
+
+function loop(timestamp) {
+  const delta = Math.min(32, timestamp - lastTimestamp);
+  lastTimestamp = timestamp;
+
+  update(delta);
+  render(timestamp);
+
+  justPressed.clear();
+  requestAnimationFrame(loop);
+}
+
+function update(delta) {
+  const previousX = player.x;
+  const previousY = player.y;
+
+  const moveLeft = keys.has("ArrowLeft") || keys.has("KeyA");
+  const moveRight = keys.has("ArrowRight") || keys.has("KeyD");
+  const jumpPressed =
+    justPressed.has("Space") ||
+    justPressed.has("ArrowUp") ||
+    justPressed.has("KeyW");
+
+  const acceleration = 0.35 * (delta / 16.666);
+  const maxSpeed = 4.2;
+  const friction = 0.82;
+  const gravity = 0.52 * (delta / 16.666);
+
+  if (moveLeft && !moveRight) {
+    player.vx = Math.max(player.vx - acceleration, -maxSpeed);
+    player.direction = -1;
+  } else if (moveRight && !moveLeft) {
+    player.vx = Math.min(player.vx + acceleration, maxSpeed);
+    player.direction = 1;
+  } else {
+    player.vx *= friction;
+    if (Math.abs(player.vx) < 0.01) {
+      player.vx = 0;
+    }
+  }
+
+  if (jumpPressed && player.onGround) {
+    player.vy = -10.8;
+    player.onGround = false;
+  }
+
+  player.vy += gravity;
+  player.x += player.vx * (delta / 16.666);
+  player.y += player.vy * (delta / 16.666);
+  player.onGround = false;
+
+  if (player.x < 0) {
+    player.x = 0;
+    player.vx = 0;
+  }
+
+  if (player.x + player.width > canvas.width) {
+    player.x = canvas.width - player.width;
+    player.vx = 0;
+  }
+
+  if (player.y + player.height >= groundY) {
+    player.y = groundY - player.height;
+    player.vy = 0;
+    player.onGround = true;
+  }
+
+  for (const platform of platforms) {
+    const isAbovePlatform = previousY + player.height <= platform.y;
+    const isWithinX =
+      player.x + player.width > platform.x &&
+      player.x < platform.x + platform.width;
+
+    if (player.vy >= 0 && isAbovePlatform && isWithinX) {
+      const bottom = player.y + player.height;
+      if (bottom >= platform.y && bottom <= platform.y + platform.height + 4) {
+        player.y = platform.y - player.height;
+        player.vy = 0;
+        player.onGround = true;
+      }
+    }
+  }
+
+  let promptText = "";
+
+  for (const crystal of crystals) {
+    if (crystal.collected) continue;
+
+    const overlapX =
+      player.x + player.width > crystal.x - crystal.radius &&
+      player.x < crystal.x + crystal.radius;
+    const overlapY =
+      player.y + player.height > crystal.y - crystal.radius &&
+      player.y < crystal.y + crystal.radius;
+
+    if (overlapX && overlapY) {
+      crystal.collected = true;
+      const leveledUp = gainExperience(60);
+      const collectedCount = crystals.filter((c) => c.collected).length;
+      ui.updateCrystals(collectedCount, crystals.length);
+      let message = "Crystal energy surges through you! +60 EXP.";
+      if (leveledUp) {
+        message += ` Level up! You reached level ${playerStats.level}.`;
+      }
+      showMessage(message, 4200);
+    }
+  }
+
+  for (const interactable of interactables) {
+    const near = isNear(player, interactable, 24);
+    if (!near) {
+      continue;
+    }
+
+    if (interactable.type === "chest") {
+      promptText = "Press E to open the chest";
+      if (justPressed.has("KeyE")) {
+        if (!interactable.opened) {
+          interactable.opened = true;
+          playerStats.hp = clamp(playerStats.hp + 12, 0, playerStats.maxHp);
+          ui.refresh(playerStats);
+          showMessage("You found herbal tonics! HP restored.", 3600);
+        } else {
+          showMessage("The chest is empty now, but still shiny.", 2800);
+        }
+      }
+    } else if (interactable.type === "fountain") {
+      promptText = "Press E to draw power from the fountain";
+      if (justPressed.has("KeyE")) {
+        if (interactable.charges > 0) {
+          interactable.charges -= 1;
+          playerStats.mp = clamp(playerStats.mp + 18, 0, playerStats.maxMp);
+          ui.refresh(playerStats);
+          showMessage("Mana rush! Your MP was restored.", 3200);
+        } else {
+          showMessage("The fountain needs time to recharge.", 3000);
+        }
+      }
+    } else if (interactable.type === "npc") {
+      promptText = "Press E to talk to Nova";
+      if (justPressed.has("KeyE")) {
+        const line = interactable.dialogue[interactable.lineIndex];
+        interactable.lineIndex =
+          (interactable.lineIndex + 1) % interactable.dialogue.length;
+        showMessage(`${interactable.name}: ${line}`, 4600);
+      }
+    }
+  }
+
+  ui.setPrompt(promptText);
+}
+
+function render(timestamp) {
+  const time = timestamp / 1000;
+
+  const backgroundGradient = ctx.createLinearGradient(0, 0, 0, canvas.height);
+  backgroundGradient.addColorStop(0, "#1a1a28");
+  backgroundGradient.addColorStop(0.6, "#25253a");
+  backgroundGradient.addColorStop(1, "#2f3d3f");
+  ctx.fillStyle = backgroundGradient;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  ctx.save();
+  ctx.globalAlpha = 0.85;
+  for (const star of stars) {
+    const twinkle = (Math.sin(time * 2 + star.twinkle) + 1) / 2;
+    ctx.fillStyle = `rgba(255, 255, 255, ${0.2 + twinkle * 0.8})`;
+    ctx.beginPath();
+    ctx.arc(star.x, star.y, star.size, 0, Math.PI * 2);
+    ctx.fill();
+  }
+  ctx.restore();
+
+  ctx.fillStyle = "#1c2b33";
+  ctx.fillRect(0, groundY, canvas.width, canvas.height - groundY);
+
+  ctx.fillStyle = "#243b25";
+  ctx.fillRect(0, groundY, canvas.width, 16);
+
+  ctx.fillStyle = "#3b5e3f";
+  for (const platform of platforms) {
+    drawRoundedRect(platform.x, platform.y, platform.width, platform.height, 6);
+  }
+
+  drawPortal(time);
+
+  for (const interactable of interactables) {
+    if (interactable.type === "chest") {
+      drawChest(interactable);
+    } else if (interactable.type === "fountain") {
+      drawFountain(interactable, time);
+    } else if (interactable.type === "npc") {
+      drawGuide(interactable, time);
+    }
+  }
+
+  for (const crystal of crystals) {
+    if (crystal.collected) continue;
+    drawCrystal(crystal, time);
+  }
+
+  drawPlayer(player, time);
+
+  if (ui.promptText) {
+    ctx.font = "20px 'Segoe UI', sans-serif";
+    ctx.fillStyle = "rgba(0, 0, 0, 0.6)";
+    const metrics = ctx.measureText(ui.promptText);
+    const x = Math.max(12, Math.min(player.x + player.width / 2 - metrics.width / 2, canvas.width - metrics.width - 12));
+    const y = player.y - 18;
+    ctx.fillRect(x - 8, y - 22, metrics.width + 16, 32);
+    ctx.fillStyle = "#f1f1ff";
+    ctx.fillText(ui.promptText, x, y);
+  }
+}
+
+function drawPortal(time) {
+  const portalX = canvas.width - 140;
+  const portalY = groundY - 120;
+  const portalWidth = 100;
+  const portalHeight = 140;
+
+  ctx.save();
+  ctx.fillStyle = "#384d6b";
+  drawRoundedRect(portalX - 12, portalY - 12, portalWidth + 24, portalHeight + 24, 24);
+
+  const glowGradient = ctx.createRadialGradient(
+    portalX + portalWidth / 2,
+    portalY + portalHeight / 2,
+    10,
+    portalX + portalWidth / 2,
+    portalY + portalHeight / 2,
+    portalWidth / 2
+  );
+  glowGradient.addColorStop(0, "rgba(150, 205, 255, 0.85)");
+  glowGradient.addColorStop(1, "rgba(100, 140, 220, 0.1)");
+  ctx.fillStyle = glowGradient;
+  drawRoundedRect(portalX, portalY, portalWidth, portalHeight, 20);
+
+  ctx.strokeStyle = `rgba(200, 240, 255, 0.55)`;
+  ctx.lineWidth = 4;
+  ctx.strokeRect(portalX + 12, portalY + 12, portalWidth - 24, portalHeight - 24);
+
+  const pulse = (Math.sin(time * 2.4) + 1) / 2;
+  ctx.lineWidth = 3;
+  ctx.strokeStyle = `rgba(180, 230, 255, ${0.35 + pulse * 0.35})`;
+  ctx.beginPath();
+  ctx.ellipse(
+    portalX + portalWidth / 2,
+    portalY + portalHeight / 2,
+    24 + pulse * 8,
+    60 + pulse * 12,
+    0,
+    0,
+    Math.PI * 2
+  );
+  ctx.stroke();
+  ctx.restore();
+}
+
+function drawPlayer(entity, time) {
+  ctx.save();
+  ctx.translate(entity.x + entity.width / 2, entity.y + entity.height);
+  ctx.scale(entity.direction, 1);
+  ctx.translate(-entity.width / 2, -entity.height);
+
+  ctx.fillStyle = "#4b6cff";
+  drawRoundedRect(4, 12, entity.width - 8, entity.height - 18, 6);
+
+  ctx.fillStyle = "#ffb6c1";
+  drawRoundedRect(6, 0, entity.width - 12, 18, 6);
+
+  ctx.fillStyle = "#8b5a2b";
+  ctx.fillRect(8, 16, entity.width - 16, 6);
+
+  ctx.fillStyle = "#111";
+  const blink = Math.sin(time * 3.2) > -0.2 ? 1 : 0.2;
+  ctx.fillRect(12, 6, 4, 4 * blink);
+  ctx.fillRect(entity.width - 16, 6, 4, 4 * blink);
+
+  ctx.fillStyle = "#c9d7ff";
+  ctx.fillRect(0, entity.height - 12, entity.width - 12, 12);
+  ctx.fillRect(entity.width - 12, entity.height - 8, 12, 8);
+  ctx.restore();
+}
+
+function drawChest(chest) {
+  ctx.save();
+  ctx.translate(chest.x, chest.y);
+  ctx.fillStyle = chest.opened ? "#a77b3b" : "#c58f3d";
+  drawRoundedRect(0, 10, chest.width, chest.height - 10, 6);
+  ctx.fillStyle = chest.opened ? "#8a5f23" : "#a16b22";
+  drawRoundedRect(0, 0, chest.width, 18, 6);
+  ctx.fillStyle = "#f7d774";
+  ctx.fillRect(chest.width / 2 - 4, 18, 8, 10);
+  ctx.restore();
+}
+
+function drawFountain(fountain, time) {
+  ctx.save();
+  ctx.translate(fountain.x, fountain.y);
+  ctx.fillStyle = "#3c4a62";
+  drawRoundedRect(0, fountain.height - 18, fountain.width, 18, 8);
+  ctx.fillStyle = "#556b8f";
+  drawRoundedRect(6, 14, fountain.width - 12, fountain.height - 32, 10);
+  const pulse = (Math.sin(time * 2) + 1) / 2;
+  ctx.fillStyle = `rgba(120, 205, 255, ${0.4 + pulse * 0.4})`;
+  drawRoundedRect(10, 20, fountain.width - 20, fountain.height - 40, 10);
+  ctx.restore();
+}
+
+function drawGuide(guide, time) {
+  ctx.save();
+  ctx.translate(guide.x, guide.y);
+  ctx.fillStyle = "#f4dede";
+  drawRoundedRect(4, 8, guide.width - 8, guide.height - 12, 10);
+  ctx.fillStyle = "#dba6ff";
+  drawRoundedRect(8, guide.height - 28, guide.width - 16, 20, 8);
+  ctx.fillStyle = "#000";
+  const bob = Math.sin(time * 2.4) * 1.5;
+  ctx.fillRect(12, 14 + bob, 4, 6);
+  ctx.fillRect(guide.width - 16, 14 + bob, 4, 6);
+  ctx.fillStyle = "#fff";
+  ctx.fillRect(12, 14 + bob, 4, 4);
+  ctx.fillRect(guide.width - 16, 14 + bob, 4, 4);
+  ctx.fillStyle = "#fefefe";
+  ctx.beginPath();
+  ctx.arc(guide.width / 2, 8, 10, Math.PI, Math.PI * 2);
+  ctx.fill();
+  ctx.restore();
+}
+
+function drawCrystal(crystal, time) {
+  ctx.save();
+  ctx.translate(crystal.x, crystal.y);
+  ctx.rotate(Math.sin(time * 2 + crystal.x * 0.01) * 0.1);
+  const gradient = ctx.createLinearGradient(-crystal.radius, -crystal.radius, crystal.radius, crystal.radius);
+  gradient.addColorStop(0, "#d9baff");
+  gradient.addColorStop(1, "#8fb5ff");
+  ctx.fillStyle = gradient;
+  ctx.beginPath();
+  ctx.moveTo(0, -crystal.radius - 6);
+  ctx.lineTo(crystal.radius, 0);
+  ctx.lineTo(0, crystal.radius + 6);
+  ctx.lineTo(-crystal.radius, 0);
+  ctx.closePath();
+  ctx.fill();
+  ctx.restore();
+}
+
+function drawRoundedRect(x, y, width, height, radius) {
+  const r = Math.min(radius, width / 2, height / 2);
+  ctx.beginPath();
+  ctx.moveTo(x + r, y);
+  ctx.lineTo(x + width - r, y);
+  ctx.quadraticCurveTo(x + width, y, x + width, y + r);
+  ctx.lineTo(x + width, y + height - r);
+  ctx.quadraticCurveTo(x + width, y + height, x + width - r, y + height);
+  ctx.lineTo(x + r, y + height);
+  ctx.quadraticCurveTo(x, y + height, x, y + height - r);
+  ctx.lineTo(x, y + r);
+  ctx.quadraticCurveTo(x, y, x + r, y);
+  ctx.closePath();
+  ctx.fill();
+}
+
+function isNear(playerEntity, object, padding) {
+  return (
+    playerEntity.x < object.x + object.width + padding &&
+    playerEntity.x + playerEntity.width > object.x - padding &&
+    playerEntity.y < object.y + object.height + padding &&
+    playerEntity.y + playerEntity.height > object.y - padding
+  );
+}
+
+function gainExperience(amount) {
+  playerStats.exp += amount;
+  let leveledUp = false;
+  while (playerStats.exp >= playerStats.maxExp) {
+    playerStats.exp -= playerStats.maxExp;
+    playerStats.level += 1;
+    playerStats.maxExp = Math.round(playerStats.maxExp * 1.2);
+    leveledUp = true;
+  }
+  ui.refresh(playerStats);
+  return leveledUp;
+}
+
+function clamp(value, min, max) {
+  return Math.max(min, Math.min(max, value));
+}
+
+function showMessage(message, duration) {
+  ui.setMessage(message);
+  if (messageTimerId) {
+    clearTimeout(messageTimerId);
+  }
+  if (duration > 0) {
+    messageTimerId = window.setTimeout(() => {
+      ui.setMessage(defaultMessage);
+      messageTimerId = 0;
+    }, duration);
+  }
+}
+
+function createInterface(stats) {
+  const root = document.createElement("div");
+  root.className = "game-root";
+
+  const canvasWrapper = document.createElement("div");
+  canvasWrapper.className = "canvas-wrapper";
+
+  const panel = document.createElement("aside");
+  panel.className = "stats-panel";
+
+  const title = document.createElement("h1");
+  title.textContent = "Astrocat Lobby";
+  panel.append(title);
+
+  const subtitle = document.createElement("p");
+  subtitle.className = "player-subtitle";
+  panel.append(subtitle);
+
+  const statsContainer = document.createElement("div");
+  statsContainer.className = "stats-container";
+  panel.append(statsContainer);
+
+  const hpBar = createStatBar("HP", "linear-gradient(90deg,#ff9a9e,#ff4e50)");
+  const mpBar = createStatBar("MP", "linear-gradient(90deg,#74f2ff,#4fa9ff)");
+  const expBar = createStatBar("EXP", "linear-gradient(90deg,#fddb92,#d1fdff)");
+
+  const crystalsLabel = document.createElement("p");
+  crystalsLabel.className = "crystal-label";
+  panel.append(crystalsLabel);
+
+  const message = document.createElement("p");
+  message.className = "message";
+  panel.append(message);
+
+  const instructions = document.createElement("ul");
+  instructions.className = "instruction-list";
+  instructions.innerHTML = `
+    <li>Move with A/D or ←/→</li>
+    <li>Jump with Space or W/↑</li>
+    <li>Press E near objects to interact</li>
+  `;
+  panel.append(instructions);
+
+  root.append(canvasWrapper, panel);
+
+  return {
+    root,
+    canvasWrapper,
+    promptText: "",
+    refresh(updatedStats) {
+      subtitle.textContent = `${updatedStats.name} — Level ${updatedStats.level} ${updatedStats.rank}`;
+      updateBar(hpBar, updatedStats.hp, updatedStats.maxHp);
+      updateBar(mpBar, updatedStats.mp, updatedStats.maxMp);
+      updateBar(expBar, updatedStats.exp, updatedStats.maxExp);
+    },
+    updateCrystals(collected, total) {
+      crystalsLabel.textContent = `Crystals collected: ${collected} / ${total}`;
+    },
+    setMessage(text) {
+      message.textContent = text;
+    },
+    setPrompt(text) {
+      this.promptText = text;
+    }
+  };
+
+  function createStatBar(labelText, fillColor) {
+    const row = document.createElement("div");
+    row.className = "stat-row";
+
+    const label = document.createElement("span");
+    label.className = "stat-label";
+    label.textContent = labelText;
+    row.append(label);
+
+    const bar = document.createElement("div");
+    bar.className = "stat-bar";
+    const fill = document.createElement("div");
+    fill.className = "stat-bar__fill";
+    fill.style.background = fillColor;
+    bar.append(fill);
+    row.append(bar);
+
+    const value = document.createElement("span");
+    value.className = "stat-value";
+    row.append(value);
+
+    statsContainer.append(row);
+
+    return { fill, value };
+  }
+
+  function updateBar(bar, current, max) {
+    const clamped = clamp(current, 0, max);
+    const percent = max === 0 ? 0 : (clamped / max) * 100;
+    bar.fill.style.width = `${percent}%`;
+    bar.value.textContent = `${Math.round(clamped)} / ${Math.round(max)}`;
+  }
+}

--- a/src/style.css
+++ b/src/style.css
@@ -1,21 +1,167 @@
 :root {
   color-scheme: dark;
+  font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
 }
 
 html,
 body {
   margin: 0;
   padding: 0;
-  background-color: #1a1a28;
-  height: 100%;
-  font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+  background: radial-gradient(circle at top, #22243a, #14141f 60%);
+  min-height: 100vh;
+  color: #f5f6ff;
 }
 
 #app {
-  width: 100%;
-  height: 100%;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 32px;
+  box-sizing: border-box;
 }
 
-canvas {
+.game-root {
+  display: flex;
+  gap: 24px;
+  width: 100%;
+  max-width: 1200px;
+  align-items: stretch;
+  flex-wrap: wrap;
+}
+
+.canvas-wrapper {
+  flex: 1 1 600px;
+  background: rgba(10, 13, 22, 0.8);
+  border-radius: 18px;
+  box-shadow: 0 24px 50px rgba(9, 15, 35, 0.5);
+  padding: 12px;
+  backdrop-filter: blur(8px);
+}
+
+.game-canvas {
+  width: 100%;
+  height: auto;
   display: block;
+  border-radius: 12px;
+  background: #0c0f18;
+}
+
+.stats-panel {
+  flex: 0 0 320px;
+  background: rgba(18, 24, 36, 0.92);
+  border-radius: 18px;
+  padding: 24px;
+  box-shadow: 0 16px 35px rgba(8, 14, 28, 0.55);
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  border: 1px solid rgba(94, 132, 255, 0.18);
+}
+
+.stats-panel h1 {
+  margin: 0;
+  font-size: 28px;
+  letter-spacing: 1px;
+  color: #c6d2ff;
+}
+
+.player-subtitle {
+  margin: 0;
+  color: #8aa0ff;
+  font-weight: 500;
+  font-size: 16px;
+}
+
+.stats-container {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.stat-row {
+  display: grid;
+  grid-template-columns: 52px 1fr auto;
+  gap: 12px;
+  align-items: center;
+}
+
+.stat-label {
+  font-size: 14px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(198, 210, 255, 0.75);
+}
+
+.stat-bar {
+  position: relative;
+  height: 14px;
+  border-radius: 999px;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.stat-bar__fill {
+  height: 100%;
+  width: 0;
+  border-radius: inherit;
+  transition: width 0.3s ease;
+}
+
+.stat-value {
+  font-variant-numeric: tabular-nums;
+  font-size: 14px;
+  color: rgba(245, 246, 255, 0.9);
+}
+
+.crystal-label {
+  margin: 0;
+  font-size: 15px;
+  color: #d5e2ff;
+}
+
+.message {
+  margin: 0;
+  min-height: 48px;
+  display: flex;
+  align-items: center;
+  color: #f7f9ff;
+  background: rgba(80, 112, 255, 0.12);
+  border: 1px solid rgba(120, 150, 255, 0.28);
+  border-radius: 12px;
+  padding: 12px 14px;
+  line-height: 1.4;
+}
+
+.instruction-list {
+  margin: 0;
+  padding-left: 18px;
+  color: rgba(210, 220, 255, 0.75);
+  font-size: 13px;
+  display: grid;
+  gap: 6px;
+}
+
+.instruction-list li::marker {
+  color: rgba(120, 150, 255, 0.6);
+}
+
+@media (max-width: 960px) {
+  #app {
+    padding: 20px;
+  }
+
+  .stats-panel {
+    flex: 1 1 300px;
+  }
+}
+
+@media (max-width: 720px) {
+  .game-root {
+    flex-direction: column;
+  }
+
+  .canvas-wrapper {
+    flex-basis: auto;
+  }
 }


### PR DESCRIPTION
## Summary
- replace the Phaser dependency with a self-contained canvas-powered lobby scene that renders a background, player, and interactable objects
- add keyboard controls, collectible crystals, and interactive chest, fountain, and guide NPC to update the player stats UI
- refresh the layout and styling for the canvas and stat panel to present the game and HUD side-by-side

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1a2042b0083249332201484d7cf21