### PR TITLE
Fix stylesheet loading without module import

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Astrocat Lobby</title>
+    <link rel="stylesheet" href="./src/style.css" />
     <link
       rel="icon"
       type="image/svg+xml"

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,3 @@
-import "./style.css";
-
 const app = document.querySelector("#app");
 if (!app) {
   throw new Error("Missing #app container");


### PR DESCRIPTION
## Summary
- link the main stylesheet in index.html so the browser requests it with a CSS MIME type
- stop importing the stylesheet from the JavaScript entry point to avoid module script errors

## Testing
- npm install *(fails: registry access forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68d1a547baf48324bc76f1f518a48d48