### PR TITLE
Fix asset loading without bundler imports

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,8 @@
-import backgroundImageUrl from "./assets/LobbyBackground.png";
-import playerSpriteUrl from "./assets/PlayerSprite.png";
+const backgroundImageUrl = new URL(
+  "./assets/LobbyBackground.png",
+  import.meta.url
+).href;
+const playerSpriteUrl = new URL("./assets/PlayerSprite.png", import.meta.url).href;
 
 const app = document.querySelector("#app");
 if (!app) {


### PR DESCRIPTION
## Summary
- load background and sprite images using URL references derived from import.meta.url
- avoid treating PNG assets as module scripts in browsers serving the files directly

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1b96e8c8883248ba6fd6eeb1a588a