### PR TITLE
Fix asset URL resolution for hosted builds

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -3,14 +3,20 @@ if (!app) {
   throw new Error("Missing #app container");
 }
 
-const baseAssetPath =
-  (typeof import.meta !== "undefined" &&
-    import.meta.env &&
-    typeof import.meta.env.BASE_URL === "string"
-    ? import.meta.env.BASE_URL
-    : "./");
-const backgroundImageUrl = `${baseAssetPath}LobbyBackground.png`;
-const playerSpriteUrl = `${baseAssetPath}PlayerSprite.png`;
+const resolveAssetUrl = (relativePath) => {
+  try {
+    return new URL(relativePath, document.baseURI).href;
+  } catch (error) {
+    console.warn(
+      `Unable to resolve asset URL for "${relativePath}" using document.baseURI. Falling back to relative path.`,
+      error
+    );
+    return relativePath;
+  }
+};
+
+const backgroundImageUrl = resolveAssetUrl("LobbyBackground.png");
+const playerSpriteUrl = resolveAssetUrl("PlayerSprite.png");
 
 const backgroundImage = new Image();
 const backgroundSource = backgroundImageUrl;


### PR DESCRIPTION
## Summary
- resolve background and sprite asset URLs relative to the document base URI so they load correctly on GitHub Pages
- add a guarded fallback that preserves functionality if the base URI lookup fails

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1c19f3bc48324b460f63c2119c6b3