### PR TITLE
Fix asset loading without module imports

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,11 @@
-import backgroundImageUrl from "./assets/LobbyBackground.png";
-import playerSpriteUrl from "./assets/PlayerSprite.png";
+const backgroundImageUrl = new URL(
+  "./assets/LobbyBackground.png",
+  import.meta.url
+).href;
+const playerSpriteUrl = new URL(
+  "./assets/PlayerSprite.png",
+  import.meta.url
+).href;
 
 const app = document.querySelector("#app");
 if (!app) {


### PR DESCRIPTION
## Summary
- load background and player sprite images using `import.meta.url` URL resolution instead of static module imports to avoid MIME errors

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1c54b21c483248f83cde7df2e9f7b