### PR TITLE
Add customizable player appearance and palette UI

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -133,6 +133,113 @@ body {
   line-height: 1.4;
 }
 
+.appearance-section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 14px;
+  border-radius: 14px;
+  background: rgba(35, 44, 70, 0.35);
+  border: 1px solid rgba(94, 132, 255, 0.16);
+}
+
+.appearance-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.appearance-title {
+  font-weight: 600;
+  color: #d3ddff;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  font-size: 13px;
+}
+
+.appearance-button {
+  padding: 6px 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(120, 150, 255, 0.5);
+  background: linear-gradient(135deg, rgba(95, 129, 255, 0.55), rgba(64, 96, 210, 0.35));
+  color: #f7f8ff;
+  font-size: 13px;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.appearance-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 18px rgba(70, 110, 255, 0.35);
+}
+
+.appearance-preview {
+  margin: 0;
+  font-size: 13px;
+  color: rgba(209, 219, 255, 0.85);
+}
+
+.appearance-swatches {
+  display: flex;
+  gap: 10px;
+}
+
+.appearance-swatch {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  border: 2px solid rgba(255, 255, 255, 0.35);
+  background: var(--appearance-color);
+  box-shadow: inset 0 0 0 1px rgba(12, 16, 28, 0.4);
+}
+
+.appearance-controls {
+  display: grid;
+  gap: 10px;
+}
+
+.appearance-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.appearance-row__label {
+  font-size: 13px;
+  color: rgba(204, 215, 255, 0.85);
+  min-width: 50px;
+}
+
+.appearance-row__options {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.appearance-color {
+  width: 22px;
+  height: 22px;
+  border-radius: 6px;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  background: var(--appearance-color);
+  padding: 0;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.appearance-color:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(80, 120, 255, 0.25);
+}
+
+.appearance-color.is-selected {
+  border-color: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 0 0 2px rgba(120, 150, 255, 0.5);
+}
+
 .instruction-list {
   margin: 0;
   padding-left: 18px;


### PR DESCRIPTION
## Summary
- define reusable appearance presets with persistence helpers and load the player palette from storage
- add an appearance customization panel with palette cycling, swatches, and local updates to the preview
- tint fallback and sprite-based player rendering based on the chosen palette and save selections during play

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1d09759948324a535ab43d01e484a