### PR TITLE
Add portal mini-game host integration

### DIFF
--- a/src/miniGameHost.js
+++ b/src/miniGameHost.js
@@ -1,0 +1,198 @@
+const miniGameEntrypoints = import.meta.glob("./minigame/main.{js,ts}");
+
+function getInitializer(module) {
+  if (!module || typeof module !== "object") {
+    return null;
+  }
+  if (typeof module.mount === "function") {
+    return module.mount;
+  }
+  if (typeof module.default === "function") {
+    return module.default;
+  }
+  return null;
+}
+
+export function createMiniGameHost(parent = document.body) {
+  const overlay = document.createElement("div");
+  overlay.className = "minigame-overlay";
+  overlay.hidden = true;
+  overlay.setAttribute("aria-hidden", "true");
+
+  const frame = document.createElement("section");
+  frame.className = "minigame-overlay__frame";
+
+  const header = document.createElement("header");
+  header.className = "minigame-overlay__header";
+
+  const title = document.createElement("h2");
+  title.className = "minigame-overlay__title";
+  title.textContent = "Portal Challenge";
+  header.append(title);
+
+  const closeButton = document.createElement("button");
+  closeButton.type = "button";
+  closeButton.className = "minigame-overlay__close";
+  closeButton.textContent = "Exit";
+  header.append(closeButton);
+
+  frame.append(header);
+
+  const content = document.createElement("div");
+  content.className = "minigame-overlay__content";
+  frame.append(content);
+
+  overlay.append(frame);
+  parent.append(overlay);
+
+  let cleanupCallback = null;
+  let openTask = null;
+  let isVisible = false;
+  let lastLoadSuccessful = false;
+
+  const handleKeydown = (event) => {
+    if (event.code === "Escape") {
+      event.preventDefault();
+      void close();
+    }
+  };
+
+  closeButton.addEventListener("click", () => {
+    void close();
+  });
+
+  overlay.addEventListener("click", (event) => {
+    if (event.target === overlay) {
+      void close();
+    }
+  });
+
+  async function runCleanup() {
+    if (!cleanupCallback) {
+      return;
+    }
+    const callback = cleanupCallback;
+    cleanupCallback = null;
+    try {
+      await callback();
+    } catch (error) {
+      console.error("Mini game cleanup failed", error);
+    }
+  }
+
+  function showPlaceholder(message) {
+    const wrapper = document.createElement("div");
+    wrapper.className = "minigame-placeholder";
+    wrapper.innerHTML = message;
+    content.replaceChildren(wrapper);
+  }
+
+  function setVisible(nextVisible) {
+    if (nextVisible === isVisible) {
+      return;
+    }
+    isVisible = nextVisible;
+    if (isVisible) {
+      overlay.hidden = false;
+      overlay.setAttribute("aria-hidden", "false");
+      overlay.classList.add("is-visible");
+      document.addEventListener("keydown", handleKeydown);
+    } else {
+      overlay.classList.remove("is-visible");
+      overlay.setAttribute("aria-hidden", "true");
+      overlay.hidden = true;
+      document.removeEventListener("keydown", handleKeydown);
+    }
+  }
+
+  async function open() {
+    if (openTask) {
+      return openTask;
+    }
+    if (isVisible) {
+      return Promise.resolve(lastLoadSuccessful);
+    }
+
+    setVisible(true);
+    showPlaceholder("<p class=\"minigame-placeholder__text\">Loading mini game…</p>");
+
+    const loader =
+      miniGameEntrypoints["./minigame/main.js"] ||
+      miniGameEntrypoints["./minigame/main.ts"];
+
+    openTask = (async () => {
+      let loadedSuccessfully = false;
+
+      if (!loader) {
+        showPlaceholder(
+          `<div class=\"minigame-placeholder__text\">` +
+            `Add your mini game entry file at <code>src/minigame/main.js</code> ` +
+            `and export a <code>mount</code> function (or default export) to start it here.` +
+            `</div>`
+        );
+      } else {
+        try {
+          const module = await loader();
+          const initializer = getInitializer(module);
+
+          if (!initializer) {
+            showPlaceholder(
+              `<div class=\"minigame-placeholder__text\">` +
+                `The mini game entry needs to export a <code>mount</code> function or ` +
+                `a default function. Update <code>src/minigame/main.js</code>.` +
+                `</div>`
+            );
+          } else {
+            content.replaceChildren();
+            const teardown = await initializer(content, { close });
+            if (typeof teardown === "function") {
+              cleanupCallback = () => Promise.resolve(teardown()).catch((error) => {
+                console.error("Mini game teardown failed", error);
+              });
+            } else if (teardown && typeof teardown.dispose === "function") {
+              cleanupCallback = () => Promise.resolve(teardown.dispose()).catch((error) => {
+                console.error("Mini game dispose failed", error);
+              });
+            }
+            loadedSuccessfully = true;
+          }
+        } catch (error) {
+          console.error("Failed to load the mini game module", error);
+          showPlaceholder(
+            `<div class=\"minigame-placeholder__text\">` +
+              `Loading the mini game failed. Check the console for details.` +
+              `</div>`
+          );
+          throw error;
+        }
+      }
+
+      lastLoadSuccessful = loadedSuccessfully;
+      return loadedSuccessfully;
+    })();
+
+    try {
+      return await openTask;
+    } finally {
+      openTask = null;
+    }
+  }
+
+  async function close() {
+    if (!isVisible && !openTask) {
+      return;
+    }
+
+    await runCleanup();
+
+    setVisible(false);
+    content.replaceChildren();
+  }
+
+  return {
+    open,
+    close,
+    isOpen: () => isVisible,
+    element: overlay
+  };
+}

--- a/src/style.css
+++ b/src/style.css
@@ -165,3 +165,109 @@ body {
     flex-basis: auto;
   }
 }
+
+.minigame-overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(6, 9, 18, 0.78);
+  backdrop-filter: blur(6px);
+  z-index: 50;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.25s ease;
+}
+
+.minigame-overlay.is-visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.minigame-overlay__frame {
+  width: min(960px, 90vw);
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+  background: linear-gradient(160deg, rgba(18, 26, 46, 0.95), rgba(10, 16, 30, 0.92));
+  border-radius: 20px;
+  box-shadow: 0 32px 60px rgba(5, 10, 30, 0.65);
+  border: 1px solid rgba(120, 150, 255, 0.28);
+  overflow: hidden;
+}
+
+.minigame-overlay__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 18px 22px;
+  background: rgba(12, 18, 32, 0.82);
+  border-bottom: 1px solid rgba(120, 150, 255, 0.2);
+}
+
+.minigame-overlay__title {
+  margin: 0;
+  font-size: 20px;
+  letter-spacing: 0.04em;
+  color: #d8e2ff;
+}
+
+.minigame-overlay__close {
+  appearance: none;
+  border: 1px solid rgba(140, 170, 255, 0.4);
+  background: rgba(98, 128, 255, 0.22);
+  color: #f5f6ff;
+  border-radius: 999px;
+  padding: 8px 18px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.minigame-overlay__close:hover {
+  background: rgba(120, 150, 255, 0.32);
+  transform: translateY(-1px);
+}
+
+.minigame-overlay__close:active {
+  transform: translateY(0);
+}
+
+.minigame-overlay__content {
+  flex: 1;
+  padding: 18px;
+  background: rgba(10, 14, 26, 0.92);
+  overflow: auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #f5f6ff;
+}
+
+.minigame-placeholder {
+  max-width: 520px;
+  text-align: center;
+  padding: 24px;
+  border-radius: 16px;
+  background: rgba(30, 40, 68, 0.6);
+  border: 1px dashed rgba(120, 150, 255, 0.45);
+  box-shadow: inset 0 0 22px rgba(10, 18, 45, 0.6);
+}
+
+.minigame-placeholder__text {
+  margin: 0;
+  line-height: 1.6;
+  color: rgba(210, 220, 255, 0.85);
+  font-size: 15px;
+}
+
+.minigame-placeholder code {
+  background: rgba(15, 20, 36, 0.8);
+  padding: 2px 6px;
+  border-radius: 6px;
+  font-family: "Fira Code", "Source Code Pro", monospace;
+  font-size: 13px;
+}


### PR DESCRIPTION
## Summary
- add a mini-game host overlay that loads `src/minigame/main.js` when the portal is activated
- wire the portal interaction to open the overlay once all crystals are collected and adjust portal visuals accordingly
- style the overlay with close controls and helpful placeholder messaging for missing mini-game code

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1d10c29548324a2e877ad257688ec