### PR TITLE
Handle missing import.meta.glob gracefully

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -10,12 +10,26 @@ const playerSpriteUrl = new URL(
 const supportsImportMetaGlob =
   typeof import.meta !== "undefined" && typeof import.meta.glob === "function";
 
-const assetManifest = supportsImportMetaGlob
-  ? import.meta.glob("./assets/*.{png,PNG}", {
+function tryCreateAssetManifest() {
+  if (!supportsImportMetaGlob) {
+    return null;
+  }
+
+  try {
+    return import.meta.glob("./assets/*.{png,PNG}", {
       eager: true,
       import: "default"
-    })
-  : null;
+    });
+  } catch (error) {
+    console.warn(
+      "import.meta.glob is unavailable in this environment. Falling back to dynamic loading.",
+      error
+    );
+    return null;
+  }
+}
+
+const assetManifest = tryCreateAssetManifest();
 
 function createEmptySprite() {
   return {


### PR DESCRIPTION
## Summary
- wrap the asset manifest creation in a helper that guards use of import.meta.glob
- log a warning and fall back to dynamic sprite loading when the API is unavailable

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1ef3f87748324864ce0482156cfc5