### PR TITLE
Add recruit missions and level-gated portal access

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -133,6 +133,106 @@ body {
   line-height: 1.4;
 }
 
+.mission-log {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px;
+  border-radius: 16px;
+  background: rgba(44, 56, 92, 0.45);
+  border: 1px solid rgba(120, 150, 255, 0.2);
+  box-shadow: inset 0 0 0 1px rgba(12, 18, 36, 0.35);
+}
+
+.mission-log__title {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+  color: #dfe6ff;
+}
+
+.mission-log__summary {
+  margin: 0;
+  color: rgba(208, 219, 255, 0.75);
+  font-size: 13px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.mission-log__requirement {
+  margin: 0;
+  font-size: 14px;
+  color: rgba(150, 180, 255, 0.8);
+  transition: color 0.3s ease;
+}
+
+.mission-log__requirement.is-complete {
+  color: #7cf3d8;
+}
+
+.mission-log__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.mission-log__item {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+  background: rgba(20, 28, 46, 0.85);
+  border-radius: 12px;
+  padding: 12px 14px;
+  border: 1px solid rgba(90, 120, 200, 0.25);
+  transition: border-color 0.3s ease, background 0.3s ease;
+}
+
+.mission-log__item.is-completed {
+  border-color: rgba(110, 255, 210, 0.4);
+  background: rgba(22, 40, 52, 0.9);
+}
+
+.mission-log__status {
+  font-size: 18px;
+  line-height: 1;
+  color: rgba(200, 220, 255, 0.75);
+  margin-top: 2px;
+}
+
+.mission-log__item.is-completed .mission-log__status {
+  color: #7cf3d8;
+}
+
+.mission-log__content {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.mission-log__name {
+  margin: 0;
+  font-weight: 600;
+  font-size: 15px;
+  color: #e6ecff;
+}
+
+.mission-log__description {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.4;
+  color: rgba(202, 213, 255, 0.75);
+}
+
+.mission-log__reward {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(255, 214, 134, 0.9);
+}
+
 .account-card {
   display: grid;
   gap: 10px;


### PR DESCRIPTION
## Summary
- introduce a recruit mission system with bulletin board, comms console, and Nova briefing interactions that grant EXP
- require reaching a target level before activating the portal while tuning EXP progression and rank titles
- surface mission progress and portal requirements in the lobby UI with new mission log styling and interactable art

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d2140ce3148324bb4deeb632bf23bd