### PR TITLE
Fix portal requirement initialization order

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -677,6 +677,8 @@ const rankThresholds = [
   { level: 8, title: "Cosmic Trailblazer" }
 ];
 
+const portalRequiredLevel = 3;
+
 const playerStats = {
   name: activeAccount?.catName ?? fallbackAccount.catName,
   handle: activeAccount?.handle ?? fallbackAccount.handle,
@@ -889,8 +891,6 @@ const portal = {
   height: 140,
   interactionPadding: 36
 };
-
-const portalRequiredLevel = 3;
 
 const interactables = [
   {


### PR DESCRIPTION
## Summary
- move the `portalRequiredLevel` constant next to other configuration so it is defined before the UI needs it, preventing a ReferenceError at startup

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d22f64f4408324a19e171b86c16a5a