### PR TITLE
Adopt MapleStory inspired UI styling

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -1,15 +1,19 @@
+@import url("https://fonts.cdnfonts.com/css/maplestory");
+@import url("https://fonts.googleapis.com/css2?family=Baloo+2:wght@400;600;700&display=swap");
+
 :root {
-  color-scheme: dark;
-  font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+  color-scheme: light;
+  font-family: "Maplestory", "Baloo 2", "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
 }
 
 html,
 body {
   margin: 0;
   padding: 0;
-  background: radial-gradient(circle at top, #22243a, #14141f 60%);
+  background: linear-gradient(180deg, #7dbbff 0%, #ffe7ff 68%, #fff6d1 100%);
   min-height: 100vh;
-  color: #f5f6ff;
+  color: #241c4f;
+  font-family: inherit;
 }
 
 #app {
@@ -60,13 +64,16 @@ body {
 .chat-board {
   display: flex;
   flex-direction: column;
-  gap: 14px;
-  background: rgba(17, 22, 38, 0.85);
-  border-radius: 18px;
-  border: 1px solid rgba(94, 132, 255, 0.25);
-  padding: 18px 20px 20px;
-  box-shadow: 0 20px 42px rgba(8, 12, 28, 0.5);
+  gap: 18px;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.95) 0%, rgba(255, 233, 218, 0.95) 100%);
+  border-radius: 32px;
+  border: 4px solid #2f47ff;
+  padding: 26px 28px 32px;
+  box-shadow:
+    0 16px 0 rgba(255, 206, 115, 0.95),
+    0 36px 60px rgba(35, 20, 68, 0.35);
   overflow: hidden;
+  position: relative;
 }
 
 .audio-unlock {
@@ -76,10 +83,12 @@ body {
   transform: translateX(-50%);
   padding: 8px 18px;
   border-radius: 999px;
-  border: 1px solid rgba(130, 160, 255, 0.45);
-  background: rgba(24, 32, 64, 0.85);
-  box-shadow: 0 12px 28px rgba(8, 12, 30, 0.4);
-  color: #e8edff;
+  border: 3px solid #2f47ff;
+  background: linear-gradient(135deg, #fff4ac, #ff99d9);
+  box-shadow:
+    0 10px 0 rgba(47, 71, 255, 0.4),
+    0 18px 28px rgba(33, 18, 64, 0.35);
+  color: #1c1c38;
   font-size: 12px;
   font-weight: 600;
   letter-spacing: 0.14em;
@@ -95,8 +104,8 @@ body {
 }
 
 .audio-unlock:focus-visible {
-  outline: 2px solid rgba(160, 190, 255, 0.85);
-  outline-offset: 2px;
+  outline: 3px solid #ffec7a;
+  outline-offset: 3px;
 }
 
 .audio-unlock.is-hidden {
@@ -135,11 +144,13 @@ body {
 .touch-controls__button {
   width: 64px;
   height: 64px;
-  border-radius: 999px;
-  border: 1px solid rgba(120, 150, 255, 0.45);
-  background: linear-gradient(135deg, rgba(30, 42, 92, 0.82), rgba(18, 24, 52, 0.9));
-  box-shadow: 0 18px 32px rgba(10, 16, 32, 0.45);
-  color: #eef2ff;
+  border-radius: 24px;
+  border: 4px solid #ffb347;
+  background: linear-gradient(145deg, #fff4b3 0%, #ff9ad9 50%, #7fa5ff 100%);
+  box-shadow:
+    0 10px 0 rgba(47, 71, 255, 0.55),
+    0 26px 36px rgba(38, 19, 72, 0.35);
+  color: #201642;
   font-size: 22px;
   font-weight: 600;
   display: flex;
@@ -149,13 +160,14 @@ body {
   touch-action: none;
   user-select: none;
   transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
-  backdrop-filter: blur(8px);
 }
 
 .touch-controls__button:active {
-  transform: scale(0.95);
-  box-shadow: 0 12px 22px rgba(10, 16, 32, 0.4);
-  background: linear-gradient(135deg, rgba(40, 58, 110, 0.86), rgba(22, 30, 64, 0.92));
+  transform: scale(0.92);
+  box-shadow:
+    0 6px 0 rgba(47, 71, 255, 0.55),
+    0 14px 26px rgba(38, 19, 72, 0.35);
+  background: linear-gradient(145deg, #ffe07a 0%, #ff7fcc 60%, #6f92ff 100%);
 }
 
 @media (hover: hover) and (pointer: fine) {
@@ -190,27 +202,29 @@ body {
   font-size: 11px;
   text-transform: uppercase;
   letter-spacing: 0.12em;
-  padding: 4px 12px;
+  padding: 6px 14px;
   border-radius: 999px;
-  border: 1px solid rgba(150, 180, 255, 0.28);
-  background: linear-gradient(135deg, rgba(70, 98, 200, 0.45), rgba(46, 68, 144, 0.55));
-  color: #e8edff;
+  border: 3px solid #ffb347;
+  background: linear-gradient(135deg, #fff7bb, #ff9bdc);
+  color: #2a1d4f;
 }
 
 .chat-board__badge--friend {
-  border-color: rgba(255, 172, 220, 0.4);
-  background: linear-gradient(135deg, rgba(174, 68, 160, 0.55), rgba(90, 40, 120, 0.5));
-  color: #ffeaff;
+  border-color: #ff8ed3;
+  background: linear-gradient(135deg, #ffe5ff, #ff8ed3);
+  color: #3c225d;
 }
 
 .chat-board__mascot {
   display: flex;
   align-items: flex-end;
-  gap: 18px;
-  border-radius: 16px;
-  border: 1px solid rgba(120, 150, 255, 0.35);
-  background: linear-gradient(135deg, rgba(40, 54, 118, 0.55), rgba(20, 26, 48, 0.85));
-  box-shadow: inset 0 0 0 1px rgba(18, 26, 60, 0.45);
+  gap: 20px;
+  border-radius: 32px;
+  border: 4px solid #2f47ff;
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.92), rgba(255, 234, 214, 0.92));
+  box-shadow:
+    0 16px 0 rgba(255, 206, 115, 0.9),
+    0 26px 42px rgba(35, 20, 68, 0.3);
   overflow: hidden;
   max-height: 0;
   padding: 0;
@@ -226,17 +240,19 @@ body {
 }
 
 .chat-board__mascot.is-active {
-  max-height: 240px;
-  padding: 18px;
-  margin-top: 4px;
+  max-height: 260px;
+  padding: 24px;
+  margin-top: 6px;
   opacity: 1;
   transform: translateX(0);
 }
 
 .chat-board__mascot[data-channel="friend"] {
-  border-color: rgba(255, 170, 220, 0.5);
-  background: linear-gradient(135deg, rgba(88, 32, 96, 0.65), rgba(36, 18, 52, 0.88));
-  box-shadow: inset 0 0 0 1px rgba(140, 40, 120, 0.25);
+  border-color: #ff8ed3;
+  background: linear-gradient(145deg, rgba(255, 246, 255, 0.95), rgba(255, 213, 242, 0.95));
+  box-shadow:
+    0 16px 0 rgba(255, 172, 220, 0.85),
+    0 26px 42px rgba(35, 20, 68, 0.3);
 }
 
 .chat-board__mascot-figure {
@@ -247,10 +263,12 @@ body {
 .chat-board__mascot-avatar {
   width: 96px;
   height: 96px;
-  border-radius: 22px;
-  border: 1px solid rgba(160, 185, 255, 0.4);
-  background: rgba(10, 14, 32, 0.65);
-  box-shadow: 0 16px 30px rgba(8, 12, 30, 0.55);
+  border-radius: 28px;
+  border: 4px solid #2f47ff;
+  background: linear-gradient(180deg, #fff3b0, #ff9bdc);
+  box-shadow:
+    0 12px 0 rgba(47, 71, 255, 0.5),
+    0 22px 32px rgba(35, 20, 68, 0.35);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -275,19 +293,31 @@ body {
   flex: 1;
   display: flex;
   flex-direction: column;
-  gap: 6px;
-  background: rgba(10, 16, 34, 0.82);
-  border-radius: 18px;
-  border: 1px solid rgba(130, 160, 255, 0.35);
-  padding: 14px 18px;
-  box-shadow: inset 0 0 0 1px rgba(24, 36, 84, 0.25);
+  gap: 8px;
+  background: linear-gradient(180deg, #ffffff 0%, #ffe9f7 100%);
+  border-radius: 32px 32px 32px 22px;
+  border: 4px solid #2f47ff;
+  padding: 20px 24px;
+  box-shadow:
+    0 10px 0 rgba(255, 206, 115, 0.85),
+    0 18px 32px rgba(35, 20, 68, 0.25);
+  position: relative;
+}
+
+.chat-board__bubble::before {
+  content: "";
+  position: absolute;
+  inset: 12px 16px 16px 18px;
+  border-radius: 22px 22px 28px 20px;
+  border: 2px dashed rgba(255, 188, 116, 0.7);
+  pointer-events: none;
 }
 
 .chat-board__bubble-label {
   font-size: 12px;
   text-transform: uppercase;
   letter-spacing: 0.14em;
-  color: rgba(198, 210, 255, 0.8);
+  color: #ff8ed3;
 }
 
 .chat-board__bubble-text {
@@ -295,17 +325,17 @@ body {
   font-size: 16px;
   line-height: 1.55;
   font-weight: 600;
-  color: #f7f9ff;
-  text-shadow: 0 0 12px rgba(90, 120, 255, 0.3);
+  color: #2a1d4f;
+  text-shadow: 0 2px 0 rgba(255, 206, 115, 0.6);
 }
 
 .chat-board__mascot[data-channel="friend"] .chat-board__bubble-label {
-  color: rgba(255, 202, 245, 0.82);
+  color: #ff66bf;
 }
 
 .chat-board__mascot[data-channel="friend"] .chat-board__bubble-text {
-  color: #ffe8ff;
-  text-shadow: 0 0 16px rgba(255, 120, 210, 0.35);
+  color: #3a1c59;
+  text-shadow: 0 2px 0 rgba(255, 172, 220, 0.7);
 }
 
 .chat-board__list {
@@ -314,36 +344,81 @@ body {
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 18px;
 }
 
 .chat-board__empty {
   margin: 0;
-  padding: 16px;
-  border-radius: 14px;
-  border: 1px dashed rgba(120, 150, 255, 0.35);
-  background: rgba(14, 18, 32, 0.6);
-  color: rgba(200, 212, 255, 0.7);
+  padding: 20px;
+  border-radius: 28px 28px 24px 18px;
+  border: 4px solid #2f47ff;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.92), rgba(255, 233, 218, 0.92));
+  color: rgba(42, 29, 79, 0.7);
   font-size: 14px;
   font-style: italic;
   text-align: center;
+  box-shadow:
+    0 12px 0 rgba(255, 206, 115, 0.7),
+    0 18px 30px rgba(35, 20, 68, 0.2);
 }
 
 .chat-board__item {
+  position: relative;
   display: flex;
   flex-direction: column;
-  gap: 6px;
-  border-radius: 14px;
-  border: 1px solid rgba(94, 132, 255, 0.28);
-  background: rgba(14, 18, 32, 0.78);
-  padding: 14px 16px;
-  box-shadow: inset 0 0 0 1px rgba(18, 24, 48, 0.4);
+  gap: 10px;
+  border-radius: 32px 32px 32px 22px;
+  border: 4px solid #2f47ff;
+  background: linear-gradient(180deg, #ffffff 0%, #ffe9f7 100%);
+  padding: 22px 24px 26px;
+  box-shadow:
+    0 12px 0 rgba(255, 206, 115, 0.85),
+    0 24px 36px rgba(35, 20, 68, 0.28);
+  overflow: visible;
+}
+
+.chat-board__item::before {
+  content: "";
+  position: absolute;
+  inset: 14px 18px 20px 20px;
+  border-radius: 24px 24px 28px 24px;
+  border: 2px dashed rgba(255, 188, 116, 0.7);
+  pointer-events: none;
+}
+
+.chat-board__item::after {
+  content: "";
+  position: absolute;
+  left: 42px;
+  bottom: -14px;
+  width: 26px;
+  height: 26px;
+  background: linear-gradient(180deg, #ffffff 0%, #ffe9f7 100%);
+  border: 4px solid #2f47ff;
+  border-top: none;
+  border-left: none;
+  transform: rotate(45deg);
+  box-shadow:
+    6px 6px 0 rgba(255, 206, 115, 0.75);
 }
 
 .chat-board__item[data-channel="friend"] {
-  border-color: rgba(255, 166, 222, 0.35);
-  background: rgba(46, 20, 64, 0.72);
-  box-shadow: inset 0 0 0 1px rgba(86, 32, 92, 0.35);
+  border-color: #ff8ed3;
+  background: linear-gradient(180deg, #fff5ff 0%, #ffd1f1 100%);
+  box-shadow:
+    0 12px 0 rgba(255, 166, 222, 0.85),
+    0 24px 36px rgba(35, 20, 68, 0.28);
+}
+
+.chat-board__item[data-channel="friend"]::before {
+  border-color: rgba(255, 166, 222, 0.7);
+}
+
+.chat-board__item[data-channel="friend"]::after {
+  background: linear-gradient(180deg, #fff5ff 0%, #ffd1f1 100%);
+  border-color: #ff8ed3;
+  box-shadow:
+    6px 6px 0 rgba(255, 166, 222, 0.8);
 }
 
 .chat-board__meta {
@@ -355,55 +430,57 @@ body {
 
 .chat-board__author {
   font-weight: 600;
-  font-size: 14px;
-  color: #dfe6ff;
+  font-size: 15px;
+  color: #2a1d4f;
 }
 
 .chat-board__item[data-channel="friend"] .chat-board__author {
-  color: #ffd8ff;
+  color: #3a1c59;
 }
 
 .chat-board__time {
   font-size: 12px;
   letter-spacing: 0.08em;
-  color: rgba(180, 194, 255, 0.65);
+  color: rgba(57, 40, 112, 0.65);
   text-transform: uppercase;
 }
 
 .chat-board__message {
   margin: 0;
-  font-size: 14px;
-  line-height: 1.55;
-  color: rgba(210, 220, 255, 0.9);
+  font-size: 15px;
+  line-height: 1.6;
+  color: #2a1d4f;
 }
 
 .chat-board__item[data-channel="friend"] .chat-board__message {
-  color: rgba(255, 220, 255, 0.9);
+  color: #431d65;
 }
 
 .stats-panel {
   flex: 0 0 320px;
-  background: rgba(18, 24, 36, 0.92);
-  border-radius: 18px;
-  padding: 24px;
-  box-shadow: 0 16px 35px rgba(8, 14, 28, 0.55);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.95) 0%, rgba(255, 241, 220, 0.95) 100%);
+  border-radius: 36px;
+  padding: 28px;
+  box-shadow:
+    0 16px 0 rgba(255, 206, 115, 0.85),
+    0 34px 54px rgba(35, 20, 68, 0.3);
   display: flex;
   flex-direction: column;
-  gap: 18px;
-  border: 1px solid rgba(94, 132, 255, 0.18);
+  gap: 22px;
+  border: 4px solid #2f47ff;
 }
 
 .stats-panel h1 {
   margin: 0;
-  font-size: 28px;
+  font-size: 32px;
   letter-spacing: 1px;
-  color: #c6d2ff;
+  color: #2f47ff;
 }
 
 .player-subtitle {
   margin: 0;
-  color: #8aa0ff;
-  font-weight: 500;
+  color: #ff8ed3;
+  font-weight: 600;
   font-size: 16px;
 }
 
@@ -424,15 +501,16 @@ body {
   font-size: 14px;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  color: rgba(198, 210, 255, 0.75);
+  color: rgba(47, 71, 255, 0.8);
 }
 
 .stat-bar {
   position: relative;
-  height: 14px;
+  height: 16px;
   border-radius: 999px;
   overflow: hidden;
-  background: rgba(255, 255, 255, 0.08);
+  background: rgba(47, 71, 255, 0.15);
+  border: 2px solid rgba(47, 71, 255, 0.3);
 }
 
 .stat-bar__fill {
@@ -440,31 +518,35 @@ body {
   width: 0;
   border-radius: inherit;
   transition: width 0.3s ease;
+  box-shadow: inset 0 -4px 0 rgba(0, 0, 0, 0.1);
 }
 
 .stat-value {
   font-variant-numeric: tabular-nums;
-  font-size: 14px;
-  color: rgba(245, 246, 255, 0.9);
+  font-size: 15px;
+  color: #2a1d4f;
 }
 
 .crystal-label {
   margin: 0;
-  font-size: 15px;
-  color: #d5e2ff;
+  font-size: 16px;
+  color: #2f47ff;
 }
 
 .message {
   margin: 0;
-  min-height: 48px;
+  min-height: 56px;
   display: flex;
   align-items: center;
-  color: #f7f9ff;
-  background: rgba(80, 112, 255, 0.12);
-  border: 1px solid rgba(120, 150, 255, 0.28);
-  border-radius: 12px;
-  padding: 12px 14px;
+  color: #2a1d4f;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.95), rgba(255, 231, 218, 0.95));
+  border: 4px solid #2f47ff;
+  border-radius: 24px 24px 20px 18px;
+  padding: 16px 18px;
   line-height: 1.4;
+  box-shadow:
+    0 10px 0 rgba(255, 206, 115, 0.8),
+    0 18px 30px rgba(35, 20, 68, 0.2);
 }
 
 .mission-log {


### PR DESCRIPTION
## Summary
- import MapleStory-inspired typefaces and apply the rounded font across the UI
- restyle chat bubbles, stats panel, and touch controls with bright MapleStory gradients, outlines, and drop shadows
- reshape dialogue entries with dashed inner borders and balloon tails to mimic MapleStory dialogue bubbles

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d23b94bfe883248efb6bc224275f9e