### PR TITLE
Fix player sprite initialization ordering

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1012,8 +1012,6 @@ const playerStats = {
   maxMp: 60
 };
 
-setPlayerSpriteFromStarter(playerStats.starterId);
-
 const defaultMessage =
   "Check the Recruit Missions panel for onboarding tasks. Use A/D or ←/→ to move. Press Space to jump.";
 let messageTimerId = 0;
@@ -1347,6 +1345,8 @@ function setPlayerSpriteFromStarter(starterId) {
   activePlayerSpriteSource = source;
   playerSpriteState.setSource(source);
 }
+
+setPlayerSpriteFromStarter(playerStats.starterId);
 
 const player = {
   x: viewport.width / 2 - 36,


### PR DESCRIPTION
## Summary
- ensure the player sprite selection runs after the sprite state is defined to avoid runtime initialization errors

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d25341fa808324a7a07c13928e1a14