### PR TITLE
Fix runtime error when resolving starter sprites

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1012,6 +1012,28 @@ const playerStats = {
   maxMp: 60
 };
 
+const playerSpriteState = createSpriteState("starter sprite");
+let activePlayerSpriteSource = null;
+
+function setPlayerSpriteFromStarter(starterId) {
+  const starter = findStarterCharacter(starterId);
+  const source = starter?.sprite ?? starter?.image ?? null;
+  if (!source) {
+    activePlayerSpriteSource = null;
+    playerSpriteState.handleError();
+    return;
+  }
+
+  if (source === activePlayerSpriteSource) {
+    return;
+  }
+
+  activePlayerSpriteSource = source;
+  playerSpriteState.setSource(source);
+}
+
+setPlayerSpriteFromStarter(playerStats.starterId);
+
 const defaultMessage =
   "Check the Recruit Missions panel for onboarding tasks. Use A/D or ←/→ to move. Press Space to jump.";
 let messageTimerId = 0;
@@ -1326,29 +1348,7 @@ function createTouchControls({ onPress, onRelease, onGesture } = {}) {
 
 const groundY = viewport.height - 96;
 
-const playerSpriteState = createSpriteState("starter sprite");
-let activePlayerSpriteSource = null;
-
-function setPlayerSpriteFromStarter(starterId) {
-  const starter = findStarterCharacter(starterId);
-  const source = starter?.sprite ?? starter?.image ?? null;
-  if (!source) {
-    activePlayerSpriteSource = null;
-    playerSpriteState.handleError();
-    return;
-  }
-
-  if (source === activePlayerSpriteSource) {
-    return;
-  }
-
-  activePlayerSpriteSource = source;
-  playerSpriteState.setSource(source);
-}
-
-setPlayerSpriteFromStarter(playerStats.starterId);
-
-const player = {
+  const player = {
   x: viewport.width / 2 - 36,
   y: groundY - 81,
   width: 72,


### PR DESCRIPTION
## Summary
- initialize the player sprite state before any starter swapping logic runs
- keep the starter sprite selection helper available without triggering temporal dead zone errors

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2553cbc0883248f7a25d155d3db70