### PR TITLE
Enlarge profile avatar on account panel

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -878,17 +878,18 @@ body {
 
 .account-card__starter {
   display: flex;
-  gap: 14px;
+  gap: 18px;
   align-items: center;
 }
 
 .account-card__starter-image {
-  width: 72px;
-  height: 72px;
-  border-radius: 18px;
-  border: 1px solid rgba(255, 255, 255, 0.22);
-  box-shadow: 0 16px 32px rgba(10, 16, 35, 0.55);
+  width: 96px;
+  height: 96px;
+  border-radius: 24px;
+  border: 2px solid rgba(255, 255, 255, 0.22);
+  box-shadow: 0 20px 36px rgba(10, 16, 35, 0.55);
   background: rgba(14, 20, 40, 0.65);
+  object-fit: cover;
 }
 
 .account-card__starter-info {


### PR DESCRIPTION
## Summary
- enlarge the Astrocat profile avatar within the stats panel account card
- adjust surrounding spacing, border, and shadow so the scaled image remains balanced
- ensure the starter portrait covers the larger frame cleanly with object-fit

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d25ae279a083248adf8843627d1d8d