### PR TITLE
Add Starcade arcade integration for AstroCats3 mini game

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,11 @@ The development server runs with Vite and will automatically reload when you cha
 ## Custom page background
 
 Add a `webpagebackground.png` file to the `public/` directory to replace the default gradient backdrop that surrounds the lobby canvas. The image is applied automatically when present and falls back to the gradient when removed.
+
+## Embedding the AstroCats3 mini game
+
+1. Copy the production build of the **AstroCats3** mini game into `public/AstroCats3/`, replacing the placeholder `index.html` with your own entry point and keeping all referenced assets alongside it.
+2. Run the lobby (`npm run dev`) and approach the glowing arcade cabinet labeled **Starcade**. Press <kbd>E</kbd> to launch the mini game inside the lobby.
+3. Close the in-game console with the **Back to lobby** button or the <kbd>Escape</kbd> key when you are finished playing.
+
+The cabinet loads `/AstroCats3/index.html` inside an iframe, so ensure all asset paths remain relative to that file. You can also open the mini game directly in a new browser tab at `/AstroCats3/index.html` to verify it deploys correctly.

--- a/public/AstroCats3/index.html
+++ b/public/AstroCats3/index.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>AstroCats Mini Game</title>
+    <style>
+      :root {
+        color-scheme: dark;
+      }
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: grid;
+        place-items: center;
+        background: radial-gradient(circle at top, #1c1a3a 0%, #0a0818 60%, #000 100%);
+        font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+        color: #f7f4ff;
+        padding: 24px;
+        box-sizing: border-box;
+        text-align: center;
+      }
+      main {
+        max-width: 680px;
+        background: rgba(28, 22, 56, 0.85);
+        border-radius: 18px;
+        border: 2px solid rgba(123, 98, 255, 0.6);
+        padding: 32px 28px;
+        box-shadow: 0 24px 60px rgba(10, 8, 30, 0.65);
+      }
+      h1 {
+        margin-top: 0;
+        font-size: clamp(1.8rem, 5vw, 2.6rem);
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+      p {
+        line-height: 1.6;
+        font-size: 1.05rem;
+        margin: 0 0 1.25rem;
+      }
+      code {
+        font-family: "Fira Mono", "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+        background: rgba(255, 255, 255, 0.08);
+        padding: 0.25em 0.5em;
+        border-radius: 6px;
+        font-size: 0.95rem;
+      }
+      a {
+        color: #7ee0ff;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Mini Game Placeholder</h1>
+      <p>
+        Drop the production build of the <strong>AstroCats3</strong> mini game into this folder so it can be
+        embedded inside the lobby&rsquo;s arcade cabinet. Replace this placeholder file with your game&rsquo;s
+        <code>index.html</code> entry point and keep all referenced assets next to it.
+      </p>
+      <p>
+        When the cabinet is activated in the lobby, it loads <code>/AstroCats3/index.html</code> inside an in-game
+        console. Keeping your asset paths relative ensures everything is served correctly by Vite.
+      </p>
+      <p>
+        You can also open the mini game directly in a new browser tab at <code>/AstroCats3/index.html</code> to verify
+        it loads as expected.
+      </p>
+    </main>
+  </body>
+</html>

--- a/src/style.css
+++ b/src/style.css
@@ -1305,6 +1305,105 @@ body {
   box-shadow: 0 12px 22px rgba(80, 120, 255, 0.45);
 }
 
+.minigame-overlay {
+  position: fixed;
+  inset: 0;
+  padding: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(10, 8, 24, 0.78);
+  backdrop-filter: blur(8px);
+  z-index: 1200;
+  overflow-y: auto;
+}
+
+.minigame-modal {
+  width: min(960px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  background: linear-gradient(160deg, rgba(18, 20, 40, 0.95), rgba(30, 26, 58, 0.9));
+  border-radius: 26px;
+  border: 3px solid rgba(120, 150, 255, 0.6);
+  padding: clamp(20px, 4vw, 32px);
+  box-shadow:
+    0 24px 0 rgba(92, 110, 255, 0.45),
+    0 36px 64px rgba(8, 6, 24, 0.55);
+}
+
+.minigame-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.minigame-title {
+  margin: 0;
+  font-size: clamp(1.4rem, 2.8vw, 1.75rem);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: #eef3ff;
+}
+
+.minigame-close {
+  padding: 10px 20px;
+  border-radius: 999px;
+  border: none;
+  background: linear-gradient(135deg, #ff9dd9, #7fa4ff);
+  color: #15152e;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  cursor: pointer;
+  box-shadow:
+    0 12px 0 rgba(36, 32, 80, 0.4),
+    0 26px 40px rgba(12, 10, 38, 0.45);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.minigame-close:hover {
+  transform: translateY(-1px);
+  box-shadow:
+    0 18px 0 rgba(36, 32, 80, 0.35),
+    0 34px 56px rgba(12, 10, 38, 0.45);
+}
+
+.minigame-close:focus-visible {
+  outline: 3px solid #ffec7a;
+  outline-offset: 3px;
+}
+
+.minigame-description,
+.minigame-support {
+  margin: 0;
+  font-size: 0.98rem;
+  color: rgba(215, 226, 255, 0.78);
+  line-height: 1.6;
+}
+
+.minigame-frame {
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  min-height: clamp(320px, 56vh, 640px);
+  border: none;
+  border-radius: 20px;
+  background: #050713;
+  box-shadow:
+    inset 0 0 0 2px rgba(80, 110, 220, 0.28),
+    0 22px 40px rgba(8, 6, 26, 0.55);
+}
+
+.minigame-support a {
+  color: #7ee0ff;
+  font-weight: 600;
+}
+
+.minigame-support a:hover {
+  text-decoration: none;
+}
+
 @media (max-width: 960px) {
   #app {
     padding: 20px;
@@ -1342,5 +1441,13 @@ body {
 
   .onboarding-nav {
     justify-content: center;
+  }
+
+  .minigame-modal {
+    padding: 20px;
+  }
+
+  .minigame-frame {
+    min-height: clamp(260px, 52vh, 520px);
   }
 }


### PR DESCRIPTION
## Summary
- add a Starcade cabinet interactable that launches the AstroCats3 mini game inside an overlay and pauses lobby input
- implement modal overlay styling plus a placeholder /AstroCats3/index.html entry point for bundling the existing mini game assets
- document how to drop the AstroCats3 build into the project so the arcade cabinet can load it

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d25d2333088324840a69f63ea41993