### PR TITLE
Sync lobby profile updates with mini game iframe

### DIFF
--- a/public/AstroCats3/scripts/app.js
+++ b/public/AstroCats3/scripts/app.js
@@ -8101,6 +8101,22 @@ document.addEventListener('DOMContentLoaded', () => {
     const DISPLAY_HIGH_SCORE_COUNT = 3;
     let highScoreData = loadHighScores();
     let playerName = loadStoredPlayerName();
+    window.addEventListener('message', (event) => {
+        if (event.origin !== window.location.origin) {
+            return;
+        }
+        const { data } = event;
+        if (!data || typeof data !== 'object') {
+            return;
+        }
+        if (data.type !== 'astrocat:minigame-profile') {
+            return;
+        }
+        if (typeof data.playerName === 'string') {
+            updatePlayerName(data.playerName);
+        }
+        // Future profile fields (cosmetics, difficulty, etc.) can be handled here.
+    });
     if (!highScoreData[playerName]) {
         highScoreData[playerName] = [];
     }

--- a/public/scripts/app.js
+++ b/public/scripts/app.js
@@ -8101,6 +8101,22 @@ document.addEventListener('DOMContentLoaded', () => {
     const DISPLAY_HIGH_SCORE_COUNT = 3;
     let highScoreData = loadHighScores();
     let playerName = loadStoredPlayerName();
+    window.addEventListener('message', (event) => {
+        if (event.origin !== window.location.origin) {
+            return;
+        }
+        const { data } = event;
+        if (!data || typeof data !== 'object') {
+            return;
+        }
+        if (data.type !== 'astrocat:minigame-profile') {
+            return;
+        }
+        if (typeof data.playerName === 'string') {
+            updatePlayerName(data.playerName);
+        }
+        // Future profile fields (cosmetics, difficulty, etc.) can be handled here.
+    });
     if (!highScoreData[playerName]) {
         highScoreData[playerName] = [];
     }


### PR DESCRIPTION
## Summary
- keep the mini game iframe reference and push the current player profile once it loads
- refresh the embedded console profile after account changes and experience gains
- listen inside both arcade builds for profile postMessage events to update the displayed player name

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d265baf7588324ba616cb17a1c15f9