### PR TITLE
Handle unavailable local storage

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -649,11 +649,25 @@ const messageBoardStorageKey = "astrocat-message-boards";
 const callSignLength = 5;
 
 function getLocalStorage() {
-  if (typeof window === "undefined" || !window.localStorage) {
+  if (typeof window === "undefined") {
     return null;
   }
 
-  return window.localStorage;
+  try {
+    const storage = window.localStorage;
+    if (!storage) {
+      return null;
+    }
+
+    const testKey = "__astrocat-storage-test__";
+    storage.setItem(testKey, "1");
+    storage.removeItem(testKey);
+
+    return storage;
+  } catch (error) {
+    console.warn("Local storage is unavailable", error);
+    return null;
+  }
 }
 
 function isValidCallSign(value) {


### PR DESCRIPTION
## Summary
- guard local storage access so it fails gracefully when the browser blocks it
- emit a warning instead of throwing so chat and call sign features still work without persistence

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d267f4df9c8324989ef45d10c9d9ae