### PR TITLE
Fix stylesheet loading error

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,6 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Astrocat Lobby</title>
-    <link rel="stylesheet" href="./src/style.css" />
     <link
       rel="icon"
       type="image/svg+xml"

--- a/src/main.js
+++ b/src/main.js
@@ -1,3 +1,5 @@
+import "./style.css";
+
 const backgroundImageUrl = new URL(
   "./assets/LobbyBackground.png",
   import.meta.url


### PR DESCRIPTION
## Summary
- remove the manual stylesheet link from `index.html` so Vite no longer requests `/src/style.css`
- import the global stylesheet from `src/main.js` to ensure styles are bundled correctly

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d26a5cecbc83248ce2efff23325d4a