### PR TITLE
Fix static CSS loading for Astrocat lobby

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,9 +1,35 @@
-import "./style.css";
-
 const backgroundImageUrl = new URL(
   "./assets/LobbyBackground.png",
   import.meta.url
 ).href;
+
+const styleSheetUrl = new URL("./style.css", import.meta.url).href;
+
+function ensureBaseStyleSheet(href) {
+  if (typeof document === "undefined") {
+    return;
+  }
+
+  const head = document.head;
+  if (!head) {
+    return;
+  }
+
+  const existingLink = Array.from(
+    document.querySelectorAll('link[rel="stylesheet"]')
+  ).find((link) => link.href === href);
+
+  if (existingLink) {
+    return;
+  }
+
+  const link = document.createElement("link");
+  link.rel = "stylesheet";
+  link.href = href;
+  head.append(link);
+}
+
+ensureBaseStyleSheet(styleSheetUrl);
 
 const supportsImportMetaGlob =
   typeof import.meta !== "undefined" && typeof import.meta.glob === "function";


### PR DESCRIPTION
## Summary
- replace the direct CSS module import with runtime stylesheet injection so the app can run without a bundler
- guard against missing DOM APIs before attaching the stylesheet link element

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d26bd90c50832487cbf9c1bb70e520