### PR TITLE
Fix background probe to respect deployment base path

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -40,7 +40,63 @@ const baseCanvasWidth = 960;
 const baseCanvasHeight = 540;
 // Place a custom background image at public/webpagebackground.png to override
 // the gradient page backdrop.
-const customPageBackgroundUrl = "/webpagebackground.png";
+
+function resolvePublicAssetUrl(relativePath) {
+  if (!relativePath) {
+    return "/";
+  }
+
+  const trimmed = relativePath.replace(/^\/+/g, "");
+  const fallback = `/${trimmed}`;
+  const baseCandidates = [];
+
+  if (
+    typeof import.meta !== "undefined" &&
+    import.meta &&
+    import.meta.env &&
+    typeof import.meta.env.BASE_URL === "string"
+  ) {
+    baseCandidates.push(import.meta.env.BASE_URL);
+  }
+
+  if (typeof document !== "undefined" && document.baseURI) {
+    baseCandidates.push(document.baseURI);
+  }
+
+  if (typeof window !== "undefined" && window.location) {
+    const { href, origin } = window.location;
+    if (href) {
+      baseCandidates.push(href);
+    }
+    if (origin && origin !== "null") {
+      baseCandidates.push(origin);
+    }
+  }
+
+  for (const base of baseCandidates) {
+    if (typeof base !== "string" || base.startsWith("about:")) {
+      continue;
+    }
+
+    try {
+      return new URL(trimmed, base).toString();
+    } catch (error) {
+      console.warn(
+        "Failed to resolve public asset URL from base",
+        base,
+        error
+      );
+    }
+  }
+
+  if (!fallback.startsWith("//")) {
+    return fallback;
+  }
+
+  return `/${fallback.replace(/^\/+/g, "")}`;
+}
+
+const customPageBackgroundUrl = resolvePublicAssetUrl("webpagebackground.png");
 let customBackgroundAvailabilityProbe = null;
 
 function shouldUseCustomPageBackground() {


### PR DESCRIPTION
## Summary
- resolve the custom page background probe against the active deployment base URL
- reuse document base URI and window location hints when computing the public asset path
- ensure the background check uses the correct absolute URL even when the app is hosted from a subdirectory

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d26c1cf5548324a5b087cf3ec5d394