### PR TITLE
Fix public manifest loading for static hosting

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,27 @@
-import publicManifest from "virtual:public-manifest";
+const PUBLIC_MANIFEST_GLOBAL_KEY = "__ASTROCAT_PUBLIC_MANIFEST__";
+
+function readPublicManifest() {
+  const globalScope =
+    typeof globalThis !== "undefined"
+      ? globalThis
+      : typeof window !== "undefined"
+        ? window
+        : null;
+
+  if (
+    globalScope &&
+    Object.prototype.hasOwnProperty.call(globalScope, PUBLIC_MANIFEST_GLOBAL_KEY)
+  ) {
+    const manifest = globalScope[PUBLIC_MANIFEST_GLOBAL_KEY];
+    if (manifest && typeof manifest === "object") {
+      return manifest;
+    }
+  }
+
+  return null;
+}
+
+const publicManifest = readPublicManifest();
 
 const backgroundImageUrl = new URL(
   "./assets/LobbyBackground.png",


### PR DESCRIPTION
## Summary
- load the public asset manifest from a global so the app works when served without Vite
- inject the manifest into the built HTML with a Vite plugin instead of a virtual module
- keep the dev server reloading when public directory assets change

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d275a1e078832481425751f7df4b37