### PR TITLE
Fix mini game entry point resolution

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -288,12 +288,10 @@ function shouldUseCustomPageBackground() {
 // The mini game entry point that loads inside the arcade cabinet overlay.
 function resolveMiniGameEntryPoint() {
   const fallback = "./AstroCats3/index.html";
+  const resolvedEntry = resolvePublicAssetUrl("AstroCats3/index.html");
 
-  if (hasPublicAsset("AstroCats3/index.html")) {
-    const resolvedEntry = resolvePublicAssetUrl("AstroCats3/index.html");
-    if (resolvedEntry && resolvedEntry !== "/") {
-      return resolvedEntry;
-    }
+  if (resolvedEntry && resolvedEntry !== "/") {
+    return resolvedEntry;
   }
 
   console.warn(


### PR DESCRIPTION
## Summary
- resolve the Starcade iframe entry point using the shared public asset helper so the absolute path is used when available
- keep the relative fallback with logging when resolution fails

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d27571489c83248556636660b9d096