### PR TITLE
Fix lobby layout to keep profile beside canvas

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -41,11 +41,12 @@ body {
   width: 100%;
   max-width: 1200px;
   align-items: stretch;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
 }
 
 .canvas-wrapper {
   flex: 1 1 600px;
+  min-width: 0;
   background: rgba(10, 13, 22, 0.8);
   border-radius: 18px;
   box-shadow: 0 24px 50px rgba(9, 15, 35, 0.5);
@@ -480,6 +481,23 @@ body {
   border: 4px solid #2f47ff;
   align-items: center;
   text-align: center;
+}
+
+@media (max-width: 1100px) {
+  .game-root {
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .canvas-wrapper {
+    width: 100%;
+  }
+
+  .stats-panel {
+    width: 100%;
+    max-width: 420px;
+    flex: 1 1 auto;
+  }
 }
 
 .stats-panel > * {


### PR DESCRIPTION
## Summary
- prevent the lobby layout from wrapping so the astronaut profile stays beside the gameplay canvas
- allow the canvas panel to shrink without forcing a wrap and add a responsive column layout fallback for narrow screens

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d27bd018f88324aaebe3db70566e9e