### PR TITLE
Set leaderboard API base URL

### DIFF
--- a/public/AstroCats3/index.html
+++ b/public/AstroCats3/index.html
@@ -796,7 +796,9 @@
             <p class="mascot-text" data-mascot-text></p>
         </div>
     </div>
-
+    <script>
+        window.NYAN_ESCAPE_API_BASE_URL = "https://api.xpal.fun";
+    </script>
     <script type="module" src="scripts/app.js"></script>
 
 </body>


### PR DESCRIPTION
## Summary
- set window.NYAN_ESCAPE_API_BASE_URL before loading the AstroCats3 bundle so the leaderboard knows where to connect

## Testing
- not run (static HTML change)


------
https://chatgpt.com/codex/tasks/task_e_68d2818674f8832486c3806306a9d92d