### PR TITLE
Add stat point allocation system

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -568,6 +568,145 @@ body {
   justify-self: center;
 }
 
+.stat-point-panel {
+  margin-top: 18px;
+  padding: 18px 20px;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.95), rgba(229, 241, 255, 0.95));
+  border: 4px solid rgba(47, 71, 255, 0.35);
+  border-radius: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  box-shadow: 0 12px 28px rgba(35, 20, 68, 0.18);
+}
+
+.stat-point-panel--highlight {
+  box-shadow:
+    0 0 0 3px rgba(255, 190, 92, 0.45),
+    0 18px 32px rgba(35, 20, 68, 0.28);
+}
+
+.stat-point-panel__header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.stat-point-panel__title {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+  color: #2a1d4f;
+}
+
+.stat-point-panel__available {
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #ff4e50;
+  background: rgba(255, 206, 115, 0.25);
+  border: 2px solid rgba(255, 190, 92, 0.6);
+  border-radius: 999px;
+  padding: 4px 12px;
+  white-space: nowrap;
+}
+
+.stat-point-panel__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.stat-point-panel__item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 12px 14px;
+  border-radius: 16px;
+  background: rgba(47, 71, 255, 0.08);
+}
+
+.stat-point-panel__info {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  flex: 1 1 auto;
+}
+
+.stat-point-panel__label {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(47, 71, 255, 0.85);
+}
+
+.stat-point-panel__description {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.4;
+  color: rgba(36, 28, 79, 0.8);
+}
+
+.stat-point-panel__controls {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.stat-point-panel__value {
+  min-width: 32px;
+  text-align: center;
+  font-variant-numeric: tabular-nums;
+  font-size: 18px;
+  font-weight: 600;
+  color: #2a1d4f;
+}
+
+.stat-point-panel__increase {
+  width: 36px;
+  height: 36px;
+  border-radius: 12px;
+  border: 3px solid #2f47ff;
+  background: linear-gradient(135deg, #fff4ac, #ff99d9);
+  color: #1c1c38;
+  font-size: 18px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+}
+
+.stat-point-panel__increase:not(:disabled):not([aria-disabled="true"]):hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 16px rgba(47, 71, 255, 0.35);
+}
+
+.stat-point-panel__increase:focus-visible {
+  outline: 3px solid #ffec7a;
+  outline-offset: 2px;
+}
+
+.stat-point-panel__increase:disabled,
+.stat-point-panel__increase[aria-disabled="true"] {
+  opacity: 0.45;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.stat-point-panel__summary {
+  margin: 0;
+  font-size: 13px;
+  color: rgba(36, 28, 79, 0.75);
+  text-align: center;
+}
+
 .crystal-label {
   margin: 0;
   font-size: 16px;


### PR DESCRIPTION
## Summary
- add player attribute definitions and derived stat calculations that power a new stat point economy
- award stat points on level up and let players spend them through an interactive stat training panel
- style the stat allocation controls to match the lobby aesthetic

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d280834b4483248174cff2f53fa521