### PR TITLE
Document expected Vite dev server output

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,18 @@ npm run dev
 
 The development server runs with Vite and will automatically reload when you change files.  To produce an optimized build run `npm run build`.
 
+When the dev server starts successfully you should see output similar to:
+
+```
+VITE v5.4.20  ready in 396 ms
+
+  ➜  Local:   http://localhost:5173/
+  ➜  Network: use --host to expose
+  ➜  press h + enter to show help
+```
+
+Open the printed local URL in your browser to explore the lobby during development.
+
 ## Custom page background
 
 Add a `webpagebackground.png` file to the `public/` directory to replace the default gradient backdrop that surrounds the lobby canvas. The image is applied automatically when present and falls back to the gradient when removed.


### PR DESCRIPTION
## Summary
- document the Vite dev server banner shown after running npm run dev
- guide developers to open the printed local URL during development

## Testing
- not run (documentation change)

------
https://chatgpt.com/codex/tasks/task_e_68d2ed3cb3a0832482a797bade3971b0