### PR TITLE
Guard import.meta.glob usage for asset manifests

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -215,16 +215,39 @@ function ensureBaseStyleSheet(href) {
 
 ensureBaseStyleSheet(styleSheetUrl);
 
+function getImportMetaGlob() {
+  if (typeof import.meta === "undefined" || !import.meta) {
+    return null;
+  }
+
+  const glob = import.meta.glob;
+  if (typeof glob !== "function") {
+    return null;
+  }
+
+  return glob.bind(import.meta);
+}
+
 function tryCreateAssetManifest() {
+  const glob = getImportMetaGlob();
+  if (!glob) {
+    if (typeof console !== "undefined") {
+      console.warn(
+        "import.meta.glob is unavailable in this environment. Falling back to dynamic loading."
+      );
+    }
+    return null;
+  }
+
   try {
-    return import.meta.glob("./assets/*.{png,PNG}", {
+    return glob("./assets/*.{png,PNG}", {
       eager: true,
       import: "default"
     });
   } catch (error) {
     if (error && typeof console !== "undefined") {
       console.warn(
-        "import.meta.glob is unavailable in this environment. Falling back to dynamic loading.",
+        "import.meta.glob failed while loading sprite assets. Falling back to dynamic loading.",
         error
       );
     }
@@ -235,15 +258,25 @@ function tryCreateAssetManifest() {
 const assetManifest = tryCreateAssetManifest();
 
 function tryCreateAudioManifest() {
+  const glob = getImportMetaGlob();
+  if (!glob) {
+    if (typeof console !== "undefined") {
+      console.warn(
+        "import.meta.glob is unavailable for audio assets. Falling back to dynamic loading."
+      );
+    }
+    return null;
+  }
+
   try {
-    return import.meta.glob("./assets/audio/*.{wav,mp3,ogg}", {
+    return glob("./assets/audio/*.{wav,mp3,ogg}", {
       eager: true,
       import: "default"
     });
   } catch (error) {
     if (error && typeof console !== "undefined") {
       console.warn(
-        "import.meta.glob is unavailable for audio assets. Falling back to dynamic loading.",
+        "import.meta.glob failed while loading audio assets. Falling back to dynamic loading.",
         error
       );
     }


### PR DESCRIPTION
## Summary
- add a helper that checks for `import.meta.glob` support before attempting to build asset manifests
- ensure sprite and audio manifest generation gracefully falls back when the API is unavailable

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2fcc68b90832493a4df08e38c9107