### PR TITLE
Update AstroCats3 mini game entry resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,4 +33,4 @@ Add a `webpagebackground.png` file to the `public/` directory to replace the def
 2. Run the lobby (`npm run dev`) and approach the glowing arcade cabinet labeled **Starcade**. Press <kbd>E</kbd> to launch the mini game inside the lobby.
 3. Close the in-game console with the **Back to lobby** button or the <kbd>Escape</kbd> key when you are finished playing.
 
-The cabinet loads `/AstroCats3/index.html` inside an iframe, so ensure all asset paths remain relative to that file. You can also open the mini game directly in a new browser tab at `/AstroCats3/index.html` to verify it deploys correctly.
+The cabinet now looks for `/public/AstroCats3/index.html` inside an iframe, falling back to `/AstroCats3/index.html` when needed, so ensure all asset paths remain relative to those files. You can also open the mini game directly in a new browser tab at `/public/AstroCats3/index.html` (or `/AstroCats3/index.html` if you rely on the legacy location) to verify it deploys correctly.

--- a/src/main.js
+++ b/src/main.js
@@ -522,14 +522,27 @@ function normaliseMiniGameEntryPoint(entry) {
 }
 
 function resolveMiniGameEntryPoint() {
-  const fallback = "./AstroCats3/index.html";
-  const resolvedEntry = resolvePublicAssetUrl("AstroCats3/index.html");
-  const normalisedEntry = normaliseMiniGameEntryPoint(resolvedEntry);
+  const candidateEntries = [
+    {
+      relative: "public/AstroCats3/index.html",
+      fallback: "./public/AstroCats3/index.html",
+    },
+    {
+      relative: "AstroCats3/index.html",
+      fallback: "./AstroCats3/index.html",
+    },
+  ];
 
-  if (normalisedEntry && normalisedEntry !== "/") {
-    return normalisedEntry;
+  for (const candidate of candidateEntries) {
+    const resolvedEntry = resolvePublicAssetUrl(candidate.relative);
+    const normalisedEntry = normaliseMiniGameEntryPoint(resolvedEntry);
+
+    if (normalisedEntry && normalisedEntry !== "/") {
+      return normalisedEntry;
+    }
   }
 
+  const [{ fallback }] = candidateEntries;
   console.warn(
     "Falling back to a relative AstroCats3 mini game entry point. Ensure public/AstroCats3/index.html is reachable from the current path."
   );


### PR DESCRIPTION
## Summary
- update the mini game entry-point resolver to prefer `public/AstroCats3/index.html` while keeping a legacy fallback
- document the new lookup order in the README so deployment expectations are clear

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d30104bf5883248d00ee22ddaa1f0b