### PR TITLE
Fix meta progress initialization order

### DIFF
--- a/public/AstroCats3/scripts/app.js
+++ b/public/AstroCats3/scripts/app.js
@@ -3608,17 +3608,6 @@ document.addEventListener('DOMContentLoaded', () => {
         postParentMessage('astrocat:minigame-transmission', { text, meta: normalizedMeta });
     };
 
-    metaProgressManager = createMetaProgressManager({
-        challengeManager: getChallengeManager(),
-        broadcast: broadcastMetaMessage
-    });
-
-    if (metaProgressManager && typeof metaProgressManager.subscribe === 'function') {
-        metaProgressManager.subscribe((snapshot) => {
-            latestMetaSnapshot = snapshot;
-        });
-    }
-
     const intelLoreEntries = [
         {
             id: 'mission',
@@ -4193,6 +4182,17 @@ document.addEventListener('DOMContentLoaded', () => {
         } catch (error) {
             storageAvailable = false;
         }
+    }
+
+    metaProgressManager = createMetaProgressManager({
+        challengeManager: getChallengeManager(),
+        broadcast: broadcastMetaMessage
+    });
+
+    if (metaProgressManager && typeof metaProgressManager.subscribe === 'function') {
+        metaProgressManager.subscribe((snapshot) => {
+            latestMetaSnapshot = snapshot;
+        });
     }
 
     const CUSTOM_LOADOUT_VERSION = 1;


### PR DESCRIPTION
## Summary
- initialize the meta progress manager after storage availability is determined so it can safely use persisted state

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d303333ca08324a1e8785ba4c337cd