### PR TITLE
Fix service worker caching errors and storage detection

### DIFF
--- a/public/AstroCats3/scripts/app.js
+++ b/public/AstroCats3/scripts/app.js
@@ -4155,12 +4155,16 @@ document.addEventListener('DOMContentLoaded', () => {
         metaProgress: 'nyanEscape.metaProgress'
     };
 
-    let storageAvailable = false;
+    var storageAvailable = false;
     try {
-        const testKey = '__nyanEscapeTest__';
-        localStorage.setItem(testKey, '1');
-        localStorage.removeItem(testKey);
-        storageAvailable = true;
+        if (typeof localStorage === 'undefined') {
+            storageAvailable = false;
+        } else {
+            const testKey = '__nyanEscapeTest__';
+            localStorage.setItem(testKey, '1');
+            localStorage.removeItem(testKey);
+            storageAvailable = true;
+        }
     } catch (error) {
         storageAvailable = false;
     }


### PR DESCRIPTION
## Summary
- skip caching partial responses and guard cache writes inside the service worker to prevent 206 failures
- harden storage availability detection so meta progress loads without temporal dead zone errors

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d304f7f73883249f919dbfb393a635