### PR TITLE
Guard challenge reward callback

### DIFF
--- a/public/AstroCats3/scripts/app.js
+++ b/public/AstroCats3/scripts/app.js
@@ -7285,6 +7285,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
         const META_PROGRESS_VERSION = 1;
 
+        let missingGrantCosmeticWarningLogged = false;
+
         const defaultState = () => ({
             version: META_PROGRESS_VERSION,
             achievements: {},
@@ -7558,11 +7560,16 @@ document.addEventListener('DOMContentLoaded', () => {
                         text: `Season pass tier unlocked: ${tier.label ?? tier.id}`,
                         meta: { type: 'season' }
                     });
-                    if (tier.reward && challengeManager?.grantCosmeticReward) {
-                        try {
-                            challengeManager.grantCosmeticReward(tier.reward, { reason: `season-${tier.id}` });
-                        } catch (error) {
-                            console.error('season reward grant failed', error);
+                    if (tier.reward) {
+                        if (typeof challengeManager?.grantCosmeticReward === 'function') {
+                            try {
+                                challengeManager.grantCosmeticReward(tier.reward, { reason: `season-${tier.id}` });
+                            } catch (error) {
+                                console.error('season reward grant failed', error);
+                            }
+                        } else if (!missingGrantCosmeticWarningLogged) {
+                            console.warn('season reward grant skipped: grantCosmeticReward callback missing');
+                            missingGrantCosmeticWarningLogged = true;
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- ensure season pass rewards only call the cosmetic grant callback when it is a function
- emit a single warning when the host challenge manager omits a functional grantCosmeticReward hook

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3149f0d0c83248652222850d3a125