### PR TITLE
Remove blocked Maplestory font import

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -1,9 +1,8 @@
-@import url("https://fonts.cdnfonts.com/css/maplestory");
 @import url("https://fonts.googleapis.com/css2?family=Baloo+2:wght@400;600;700&display=swap");
 
 :root {
   color-scheme: light;
-  font-family: "Maplestory", "Baloo 2", "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+  font-family: "Baloo 2", "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
   /* The gradient fallback shown whenever no custom background image is present. */
   --page-background-base: linear-gradient(180deg, #7dbbff 0%, #ffe7ff 68%, #fff6d1 100%);
   /* Populated at runtime when public/webpagebackground.png is available. */


### PR DESCRIPTION
## Summary
- remove the Maplestory webfont import that Chrome and Brave block with a Cross-Origin-Resource-Policy error
- rely on the Baloo 2 Google Font fallback to keep the existing typography without cross-origin failures

## Testing
- npm run build
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d3168c5acc83248cbb596a4797d982