### PR TITLE
Adjust minigame overlay dimensions

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -1510,7 +1510,7 @@ body {
 }
 
 .minigame-modal {
-  width: min(960px, 100%);
+  width: min(1280px, 100%);
   display: flex;
   flex-direction: column;
   gap: 18px;
@@ -1577,7 +1577,8 @@ body {
 .minigame-frame {
   width: 100%;
   aspect-ratio: 16 / 9;
-  min-height: clamp(320px, 56vh, 640px);
+  min-height: clamp(360px, 60vh, 720px);
+  max-height: min(720px, 80vh);
   border: none;
   border-radius: 20px;
   background: #050713;


### PR DESCRIPTION
## Summary
- expand the arcade overlay modal width so the embedded mini game has room to scale to its native aspect ratio
- raise the iframe height limits to ensure the full 16:9 game content remains visible while keeping it within the viewport

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d3187d3a6c8324b341589a8cbb2f9d