### PR TITLE
Fix season pass track initialization error

### DIFF
--- a/public/AstroCats3/scripts/app.js
+++ b/public/AstroCats3/scripts/app.js
@@ -6400,7 +6400,7 @@ document.addEventListener('DOMContentLoaded', () => {
     metaProgressManager = createMetaProgressManager({
         challengeManager: getChallengeManager(),
         broadcast: broadcastMetaMessage,
-        seasonTrack: () => SEASON_PASS_TRACK
+        seasonTrack: SEASON_PASS_TRACK
     });
 
     if (metaProgressManager && typeof metaProgressManager.subscribe === 'function') {


### PR DESCRIPTION
## Summary
- pass the resolved season pass track object into the meta progress manager instead of a factory

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d31a99968083249bbddb29881233dc