### PR TITLE
Prevent page scroll during player movement

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -24,6 +24,17 @@ body {
   background-color: #7dbbff;
 }
 
+html.is-scroll-locked,
+html.is-scroll-locked body,
+body.is-scroll-locked {
+  overflow: hidden;
+  overscroll-behavior: none;
+}
+
+body.is-scroll-locked {
+  touch-action: none;
+}
+
 
 #app {
   min-height: 100vh;


### PR DESCRIPTION
## Summary
- lock the document scroll while movement inputs are active to keep the lobby static during sprite movement
- extend the movement key handling to include WASD and release the lock on blur events
- add CSS support for the scroll-lock class so the page and board stop scrolling during gameplay

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d31e6a51e483249024e521819bb552