### PR TITLE
Avoid early access to season track during meta manager init

### DIFF
--- a/public/AstroCats3/scripts/app.js
+++ b/public/AstroCats3/scripts/app.js
@@ -6402,20 +6402,10 @@ document.addEventListener('DOMContentLoaded', () => {
             return metaProgressManager;
         }
 
-        let seasonTrack;
-        try {
-            seasonTrack = SEASON_PASS_TRACK;
-        } catch (error) {
-            if (error instanceof ReferenceError) {
-                return null;
-            }
-            throw error;
-        }
-
         const manager = createMetaProgressManager({
             challengeManager: getChallengeManager(),
             broadcast: broadcastMetaMessage,
-            seasonTrack
+            seasonTrack: () => SEASON_PASS_TRACK
         });
 
         if (!manager) {


### PR DESCRIPTION
## Summary
- adjust meta progress initialization to pass a lazy getter for the season pass track so setup waits until the constant is defined

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d32034b1508324a5da92e954192cc4