### PR TITLE
Fix season pass initialization timing

### DIFF
--- a/public/AstroCats3/scripts/app.js
+++ b/public/AstroCats3/scripts/app.js
@@ -6180,6 +6180,8 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     ];
 
+    let seasonPassTrackRef = null;
+
     const SEASON_PASS_TRACK = {
         seasonId: '2024-quantum',
         label: 'Season 3 · Quantum Drift',
@@ -6212,6 +6214,8 @@ document.addEventListener('DOMContentLoaded', () => {
             }
         ]
     };
+
+    seasonPassTrackRef = SEASON_PASS_TRACK;
 
     const CHALLENGE_DEFINITIONS = {
         daily: [
@@ -6405,7 +6409,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const manager = createMetaProgressManager({
             challengeManager: getChallengeManager(),
             broadcast: broadcastMetaMessage,
-            seasonTrack: () => SEASON_PASS_TRACK
+            seasonTrack: () => seasonPassTrackRef
         });
 
         if (!manager) {


### PR DESCRIPTION
## Summary
- cache the season pass track in a mutable reference before the constant is initialised
- ensure the meta progress manager fetches the season data through the safe reference to avoid temporal dead zone errors

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d3250b16b08324bfd11ab9464a02b1