### PR TITLE
Disable season pass track to prevent initialization crash

### DIFF
--- a/public/AstroCats3/scripts/app.js
+++ b/public/AstroCats3/scripts/app.js
@@ -6180,42 +6180,9 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     ];
 
+    // Disable the season pass track to prevent initialization issues that
+    // currently block the game from loading in some environments.
     let seasonPassTrackRef = null;
-
-    const SEASON_PASS_TRACK = {
-        seasonId: '2024-quantum',
-        label: 'Season 3 · Quantum Drift',
-        tiers: [
-            { id: 'tier-1', threshold: 40, label: 'Tier 1 — Recon Cache' },
-            {
-                id: 'tier-2',
-                threshold: 100,
-                label: 'Tier 2 — Quantum Wake',
-                reward: {
-                    type: 'cosmetic',
-                    category: 'trail',
-                    id: 'quantum',
-                    label: 'Quantum Drift Trail',
-                    rarity: 'legendary'
-                }
-            },
-            { id: 'tier-3', threshold: 180, label: 'Tier 3 — Vanguard Cache' },
-            {
-                id: 'tier-4',
-                threshold: 260,
-                label: 'Tier 4 — Embercore Monarch',
-                reward: {
-                    type: 'cosmetic',
-                    category: 'skin',
-                    id: 'embercore',
-                    label: 'Embercore Monarch Hull',
-                    rarity: 'mythic'
-                }
-            }
-        ]
-    };
-
-    seasonPassTrackRef = SEASON_PASS_TRACK;
 
     const CHALLENGE_DEFINITIONS = {
         daily: [
@@ -6356,8 +6323,8 @@ document.addEventListener('DOMContentLoaded', () => {
                 title: milestone.title ?? milestone.id
             });
         }
-        if (SEASON_PASS_TRACK?.tiers) {
-            for (const tier of SEASON_PASS_TRACK.tiers) {
+        if (seasonPassTrackRef?.tiers) {
+            for (const tier of seasonPassTrackRef.tiers) {
                 if (!tier || !tier.reward) {
                     continue;
                 }


### PR DESCRIPTION
## Summary
- disable the season pass track so the game no longer hits a ReferenceError during startup
- update cosmetic reward registration to account for the missing season pass tiers

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d327e3f674832498e9a1922e508065