### PR TITLE
Guard meta progress initialization when season track disabled

### DIFF
--- a/public/AstroCats3/scripts/app.js
+++ b/public/AstroCats3/scripts/app.js
@@ -6373,6 +6373,14 @@ document.addEventListener('DOMContentLoaded', () => {
             return metaProgressManager;
         }
 
+        // Skip initialization entirely when the season pass track has been
+        // disabled or failed to load. Attempting to create the manager would
+        // otherwise trigger access to the deferred season track definition and
+        // throw before it becomes available in some environments.
+        if (!seasonPassTrackRef) {
+            return null;
+        }
+
         const manager = createMetaProgressManager({
             challengeManager: getChallengeManager(),
             broadcast: broadcastMetaMessage,


### PR DESCRIPTION
## Summary
- short-circuit meta progress initialization when the season pass track is unavailable
- document why the guard exists to avoid deferred season data reference errors

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d32f73cfb4832486807c9a9ad49d4c