### PR TITLE
Fix season pass initialization error

### DIFF
--- a/public/AstroCats3/scripts/app.js
+++ b/public/AstroCats3/scripts/app.js
@@ -6180,9 +6180,15 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     ];
 
-    // Disable the season pass track to prevent initialization issues that
-    // currently block the game from loading in some environments.
-    let seasonPassTrackRef = null;
+    // Provide a minimal placeholder season track so meta progress initialisation
+    // never touches the original SEASON_PASS_TRACK constant when it is missing.
+    // This prevents a ReferenceError that previously stopped the app from
+    // booting before the real season data could load.
+    let seasonPassTrackRef = {
+        seasonId: 'season-disabled',
+        label: 'Season Pass',
+        tiers: []
+    };
 
     const CHALLENGE_DEFINITIONS = {
         daily: [


### PR DESCRIPTION
## Summary
- provide a placeholder season pass track so meta progress initialization no longer references an undefined SEASON_PASS_TRACK constant
- document why the placeholder exists to avoid boot failures when season data is absent

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d3407435d48324ac31eef5c0ccb56a