### PR TITLE
Disable service worker registration on production hosts

### DIFF
--- a/public/AstroCats3/scripts/app.js
+++ b/public/AstroCats3/scripts/app.js
@@ -24,6 +24,12 @@ const serviceWorkerSupported =
     typeof window !== 'undefined' &&
     'serviceWorker' in navigator &&
     typeof navigator.serviceWorker?.register === 'function';
+
+const serviceWorkerRegistrationEnabled =
+    serviceWorkerSupported &&
+    typeof window !== 'undefined' &&
+    (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1');
+
 let serviceWorkerRegistrationPromise = null;
 
 function markOfflineCapabilityReady() {
@@ -33,7 +39,7 @@ function markOfflineCapabilityReady() {
 }
 
 function registerGameServiceWorker() {
-    if (!serviceWorkerSupported) {
+    if (!serviceWorkerRegistrationEnabled) {
         return null;
     }
     if (serviceWorkerRegistrationPromise) {
@@ -60,7 +66,20 @@ function registerGameServiceWorker() {
     return serviceWorkerRegistrationPromise;
 }
 
-if (serviceWorkerSupported) {
+if (serviceWorkerSupported && !serviceWorkerRegistrationEnabled) {
+    if (typeof navigator.serviceWorker?.getRegistrations === 'function') {
+        navigator.serviceWorker
+            .getRegistrations()
+            .then((registrations) => {
+                for (const registration of registrations) {
+                    registration.unregister().catch(() => {});
+                }
+            })
+            .catch(() => {});
+    }
+}
+
+if (serviceWorkerRegistrationEnabled) {
     if (navigator.serviceWorker.controller) {
         markOfflineCapabilityReady();
     }


### PR DESCRIPTION
## Summary
- disable registering the game service worker on non-localhost environments to avoid cached script issues
- proactively unregister any existing service worker registrations when running in production hosts

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d342246e608324a0bbb5d013763500