### PR TITLE
Fix season pass track resolution for Chrome

### DIFF
--- a/public/AstroCats3/scripts/app.js
+++ b/public/AstroCats3/scripts/app.js
@@ -6228,16 +6228,6 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     function resolveSeasonPassTrack() {
-        try {
-            if (typeof SEASON_PASS_TRACK !== 'undefined' && SEASON_PASS_TRACK) {
-                return SEASON_PASS_TRACK;
-            }
-        } catch (error) {
-            if (!(error instanceof ReferenceError)) {
-                throw error;
-            }
-        }
-
         const globalScope =
             typeof globalThis !== 'undefined'
                 ? globalThis
@@ -6245,7 +6235,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     ? window
                     : null;
 
-        if (globalScope && globalScope.SEASON_PASS_TRACK) {
+        if (globalScope && typeof globalScope.SEASON_PASS_TRACK !== 'undefined') {
             return globalScope.SEASON_PASS_TRACK;
         }
 


### PR DESCRIPTION
## Summary
- update the season pass track resolver to avoid touching the SEASON_PASS_TRACK identifier before it exists
- rely on the global scope property when available so Chrome no longer throws a ReferenceError during startup

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d34d80ff00832491cc11ec2f9723b1