### PR TITLE
Prevent season track lookup ReferenceError during initialization

### DIFF
--- a/public/AstroCats3/scripts/app.js
+++ b/public/AstroCats3/scripts/app.js
@@ -6235,8 +6235,17 @@ document.addEventListener('DOMContentLoaded', () => {
                     ? window
                     : null;
 
-        if (globalScope && typeof globalScope.SEASON_PASS_TRACK !== 'undefined') {
-            return globalScope.SEASON_PASS_TRACK;
+        if (globalScope) {
+            try {
+                const track = globalScope.SEASON_PASS_TRACK;
+                if (typeof track !== 'undefined') {
+                    return track;
+                }
+            } catch (error) {
+                if (!(error instanceof ReferenceError)) {
+                    throw error;
+                }
+            }
         }
 
         return null;


### PR DESCRIPTION
## Summary
- guard season pass track resolution against ReferenceErrors when the global season track binding has not been initialised
- keep the previous behaviour of returning a disabled track when the real data is not yet available

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d3501612608324a3f2f01135cbbc04