### PR TITLE
Handle missing season pass data without ReferenceError

### DIFF
--- a/public/AstroCats3/scripts/app.js
+++ b/public/AstroCats3/scripts/app.js
@@ -7374,6 +7374,19 @@ document.addEventListener('DOMContentLoaded', () => {
                 }
                 throw error;
             }
+        } else {
+            try {
+                // Trigger access to the binding early so environments with
+                // deferred season data defined via top-level const bindings do
+                // not throw later during initialization when the variable is
+                // still in its temporal dead zone.
+                seasonTrack;
+            } catch (error) {
+                if (error instanceof ReferenceError) {
+                    return null;
+                }
+                throw error;
+            }
         }
 
         if (!seasonTrack) {


### PR DESCRIPTION
## Summary
- guard meta progress initialisation against ReferenceError by safely touching the season track binding before use
- bail out early when the deferred season track data is still unavailable so the lobby continues booting

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d3a6fdc40c83248d0e7d902095de5a