### PR TITLE
Move mini-game loadout management to lobby

### DIFF
--- a/public/AstroCats3/index.html
+++ b/public/AstroCats3/index.html
@@ -319,7 +319,7 @@
                 <h2 class="card-title" id="loadoutCardTitle">Custom Loadouts</h2>
                 <div class="card-body">
                     <p class="custom-loadout-description">
-                        Capture two personalized presets. Pick your pilot, suit, stream, and weapon, then save the configuration for fast launches.
+                        Loadouts are now configured from the Astrocat Lobby. Review the presets you saved there before launch and hop in when you are ready.
                     </p>
                     <div class="custom-loadout-section" id="customLoadoutSection" aria-live="polite">
                         <div class="custom-loadout-grid" data-loadout-grid role="list"></div>

--- a/public/AstroCats3/styles/main.css
+++ b/public/AstroCats3/styles/main.css
@@ -1333,6 +1333,19 @@ body.touch-enabled #preflightPrompt .desktop-only {
     border-color: rgba(248, 113, 113, 0.6);
 }
 
+.custom-loadout-card.is-readonly {
+    cursor: default;
+}
+
+.custom-loadout-card.is-readonly:hover {
+    transform: none;
+}
+
+.custom-loadout-card.is-readonly .custom-loadout-header-actions,
+.custom-loadout-card.is-readonly .custom-loadout-apply {
+    display: none;
+}
+
 .custom-loadout-badge {
     position: absolute;
     top: 12px;
@@ -1558,6 +1571,10 @@ body.touch-enabled #preflightPrompt .desktop-only {
     min-height: 0.9rem;
     font-size: 0.7rem;
     color: rgba(148, 210, 255, 0.82);
+}
+
+.custom-loadout-status.info {
+    color: rgba(196, 210, 255, 0.85);
 }
 
 .custom-loadout-status.error {

--- a/src/style.css
+++ b/src/style.css
@@ -694,6 +694,197 @@ body.is-scroll-locked {
   color: #241c4f;
 }
 
+.loadout-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  width: 100%;
+  padding: 18px;
+  border-radius: 20px;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.88), rgba(236, 233, 255, 0.9));
+  border: 2px solid rgba(255, 99, 195, 0.28);
+  box-shadow: inset 0 0 0 1px rgba(255, 99, 195, 0.12);
+}
+
+.loadout-panel.is-disabled {
+  opacity: 0.92;
+}
+
+.loadout-panel__header {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.loadout-panel__title {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+  color: #ff63c3;
+}
+
+.loadout-panel__description {
+  margin: 0;
+  font-size: 13px;
+  color: rgba(36, 28, 79, 0.68);
+}
+
+.loadout-panel__form {
+  display: grid;
+  gap: 12px;
+}
+
+.loadout-panel__field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.loadout-panel__label {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(36, 28, 79, 0.64);
+}
+
+.loadout-panel__input,
+.loadout-panel__select {
+  appearance: none;
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: 1px solid rgba(47, 71, 255, 0.24);
+  background: rgba(255, 255, 255, 0.96);
+  color: #241c4f;
+  font-size: 14px;
+  font-family: inherit;
+  box-shadow: 0 4px 14px rgba(36, 19, 72, 0.08);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.loadout-panel__select {
+  cursor: pointer;
+}
+
+.loadout-panel__input:focus-visible,
+.loadout-panel__select:focus-visible {
+  outline: none;
+  border-color: #ff63c3;
+  box-shadow: 0 0 0 3px rgba(255, 99, 195, 0.28);
+}
+
+.loadout-panel__input:disabled,
+.loadout-panel__select:disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
+}
+
+.loadout-summary {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid rgba(255, 147, 224, 0.32);
+  box-shadow: 0 10px 20px rgba(36, 19, 72, 0.08);
+}
+
+.loadout-summary__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.loadout-summary__title {
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(36, 28, 79, 0.74);
+}
+
+.loadout-summary__active-badge {
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: linear-gradient(135deg, rgba(255, 147, 224, 0.92), rgba(108, 182, 255, 0.92));
+  color: #fff;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.loadout-summary__active-badge[hidden] {
+  display: none;
+}
+
+.loadout-summary__list {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 8px 12px;
+  margin: 0;
+}
+
+.loadout-summary__label {
+  margin: 0;
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(36, 28, 79, 0.55);
+}
+
+.loadout-summary__value {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+  color: #241c4f;
+}
+
+.loadout-panel__equip {
+  align-self: flex-start;
+  border: none;
+  border-radius: 999px;
+  padding: 10px 20px;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  background: linear-gradient(135deg, rgba(255, 147, 224, 0.95), rgba(108, 182, 255, 0.95));
+  color: #fff;
+  cursor: pointer;
+  box-shadow: 0 14px 28px rgba(103, 99, 255, 0.35);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.loadout-panel__equip:hover,
+.loadout-panel__equip:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 32px rgba(108, 182, 255, 0.45);
+  outline: none;
+}
+
+.loadout-panel__equip:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+.loadout-panel__status {
+  margin: 0;
+  font-size: 12px;
+  color: rgba(36, 28, 79, 0.62);
+}
+
+.loadout-panel__status.is-success {
+  color: #1f8b4c;
+}
+
+.loadout-panel__status.is-error {
+  color: #b4233b;
+}
+
 @keyframes attribute-points-pulse {
   0% {
     transform: scale(1);


### PR DESCRIPTION
## Summary
- add a side panel in the lobby to configure Starcade loadout slots and persist them to local storage
- treat custom loadouts in the mini game as read-only when embedded, syncing the stored active slot from the lobby
- refresh styling and copy to direct players toward the lobby-managed presets

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d3ab1d10248324988ec45f6d4f8aab