### PR TITLE
Handle season pass initialization ReferenceError

### DIFF
--- a/public/AstroCats3/scripts/app.js
+++ b/public/AstroCats3/scripts/app.js
@@ -5979,11 +5979,22 @@ document.addEventListener('DOMContentLoaded', () => {
             disableSeasonPassUI();
             return null;
         }
-        const manager = createMetaProgressManager({
-            challengeManager: getChallengeManager(),
-            broadcast: broadcastMetaMessage,
-            seasonTrack: () => seasonPassTrackRef
-        });
+        let manager = null;
+        try {
+            manager = createMetaProgressManager({
+                challengeManager: getChallengeManager(),
+                broadcast: broadcastMetaMessage,
+                seasonTrack: () => seasonPassTrackRef
+            });
+        }
+        catch (error) {
+            if (error instanceof ReferenceError) {
+                seasonPassTrackRef = DISABLED_SEASON_PASS_TRACK;
+                disableSeasonPassUI();
+                return null;
+            }
+            throw error;
+        }
         if (!manager) {
             return null;
         }

--- a/public/AstroCats3/scripts/app.source.js
+++ b/public/AstroCats3/scripts/app.source.js
@@ -6505,11 +6505,21 @@ const LOADOUTS_MANAGED_EXTERNALLY = true;
             return null;
         }
 
-        const manager = createMetaProgressManager({
-            challengeManager: getChallengeManager(),
-            broadcast: broadcastMetaMessage,
-            seasonTrack: () => seasonPassTrackRef
-        });
+        let manager = null;
+        try {
+            manager = createMetaProgressManager({
+                challengeManager: getChallengeManager(),
+                broadcast: broadcastMetaMessage,
+                seasonTrack: () => seasonPassTrackRef
+            });
+        } catch (error) {
+            if (error instanceof ReferenceError) {
+                seasonPassTrackRef = DISABLED_SEASON_PASS_TRACK;
+                disableSeasonPassUI();
+                return null;
+            }
+            throw error;
+        }
 
         if (!manager) {
             return null;


### PR DESCRIPTION
## Summary
- wrap meta progress manager creation so ReferenceErrors from deferred season pass data no longer crash the app
- disable the season pass UI when the season data is still unavailable after catching the ReferenceError

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d3c09035688324b09b91a3afa7b9d0