### PR TITLE
Remove season pass features from mini game

### DIFF
--- a/public/AstroCats3/index.html
+++ b/public/AstroCats3/index.html
@@ -285,24 +285,6 @@
                             <h3>Reward Catalogue</h3>
                             <ul id="rewardCatalogueList" class="reward-catalogue" role="list" aria-live="polite"></ul>
                         </section>
-                        <section
-                            id="seasonPassPanel"
-                            class="meta-card season-pass-card"
-                            aria-live="polite"
-                            hidden
-                        >
-                            <h3>Season Pass</h3>
-                            <p id="seasonPassSummary" class="meta-card-summary"></p>
-                            <div
-                                class="season-pass-progress"
-                                role="progressbar"
-                                aria-valuemin="0"
-                                aria-valuemax="100"
-                            >
-                                <div id="seasonPassProgressFill"></div>
-                            </div>
-                            <ol id="seasonPassTierList" class="season-pass-tier-list" role="list"></ol>
-                        </section>
                         <section class="meta-card community-card">
                             <h3>Community Goals</h3>
                             <ul id="communityGoalList" class="community-goal-list" role="list" aria-live="polite"></ul>

--- a/public/AstroCats3/styles/main.css
+++ b/public/AstroCats3/styles/main.css
@@ -1844,68 +1844,6 @@ body.touch-enabled #preflightPrompt .desktop-only {
     color: rgba(148, 163, 184, 0.95);
 }
 
-.season-pass-progress {
-    position: relative;
-    width: 100%;
-    height: 10px;
-    border-radius: 999px;
-    background: rgba(30, 58, 138, 0.45);
-    overflow: hidden;
-}
-
-#seasonPassProgressFill {
-    position: absolute;
-    inset: 0;
-    width: 0;
-    border-radius: 999px;
-    background: linear-gradient(90deg, #f472b6, #fbbf24);
-    transition: width 200ms ease;
-}
-
-.season-pass-tier-list {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 10px;
-}
-
-.season-pass-tier {
-    border: 1px solid rgba(148, 210, 255, 0.14);
-    border-radius: 12px;
-    padding: 10px 12px;
-    background: rgba(15, 23, 42, 0.5);
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
-}
-
-.season-pass-tier.unlocked {
-    border-color: rgba(250, 204, 21, 0.5);
-}
-
-.season-pass-tier.claimed {
-    opacity: 0.85;
-}
-
-.season-pass-tier-label {
-    font-weight: 600;
-    color: rgba(226, 232, 240, 0.92);
-}
-
-.season-pass-tier-threshold {
-    font-size: 0.72rem;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-    color: rgba(148, 163, 184, 0.95);
-}
-
-.season-pass-tier-reward {
-    font-size: 0.78rem;
-    color: rgba(253, 224, 71, 0.92);
-}
-
 .community-goal-list {
     list-style: none;
     margin: 0;


### PR DESCRIPTION
## Summary
- remove the season pass panel from the mini game UI and delete the related styles
- drop season-pass state handling from the meta progress manager while keeping achievements and community goals intact
- regenerate the transpiled bundle to reflect the removal of season pass features

## Testing
- npm run build *(fails: vite is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3c3bfa6bc832493d249d69913ec9e