### PR TITLE
Add level-up feedback for mini game rewards

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -3975,8 +3975,7 @@ if (typeof window !== "undefined") {
         0,
         Math.round(Number.isFinite(summary.xpAward) ? summary.xpAward : Number(summary.xpAward) || 0)
       );
-      gainExperience(normalizedXp);
-      ui.refresh(playerStats);
+      const leveledUp = gainExperience(normalizedXp);
 
       const playerName =
         typeof summary.player === "string" && summary.player.trim().length
@@ -3994,7 +3993,10 @@ if (typeof window !== "undefined") {
           ? summary.formattedTime
           : formatRunDuration(timeMs);
       const xpLine = normalizedXp > 0 ? ` +${normalizedXp} XP` : "";
-      const messageText = `${playerName} logged ${formattedScore} pts in ${formattedTime} (x${bestStreak} streak).${xpLine}`;
+      let messageText = `${playerName} logged ${formattedScore} pts in ${formattedTime} (x${bestStreak} streak).${xpLine}`;
+      if (leveledUp) {
+        messageText += ` Level up! You reached level ${playerStats.level}.`;
+      }
       showMessage(
         {
           text: messageText,


### PR DESCRIPTION
## Summary
- include level-up detection when mini game runs report XP awards
- append level-up celebration to the mission feed message for improved feedback

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d3c61514e48324990835e10b14e562