### PR TITLE
Handle missing season pass track metadata

### DIFF
--- a/public/AstroCats3/scripts/app.js
+++ b/public/AstroCats3/scripts/app.js
@@ -6745,18 +6745,29 @@ document.addEventListener('DOMContentLoaded', () => {
     function createMetaProgressManager({ challengeManager, broadcast } = {}) {
         var _a;
         const META_PROGRESS_VERSION = 1;
-        const defaultState = () => ({
-            version: META_PROGRESS_VERSION,
-            achievements: {},
-            communityGoals: COMMUNITY_GOALS.map((goal) => ({
-                id: goal.id,
-                progress: 0,
-                contributions: 0,
-                completedAt: null,
-                lastBroadcastPercent: 0
-            })),
-            streak: { milestonesEarned: [] }
-        });
+        const defaultState = () => {
+            const baseState = {
+                version: META_PROGRESS_VERSION,
+                achievements: {},
+                communityGoals: COMMUNITY_GOALS.map((goal) => ({
+                    id: goal.id,
+                    progress: 0,
+                    contributions: 0,
+                    completedAt: null,
+                    lastBroadcastPercent: 0
+                })),
+                streak: { milestonesEarned: [] }
+            };
+            try {
+                baseState.seasonPass = { track: SEASON_PASS_TRACK };
+            }
+            catch (error) {
+                if (!(error instanceof ReferenceError)) {
+                    throw error;
+                }
+            }
+            return baseState;
+        };
         const buildSafeDefaultState = () => {
             try {
                 return defaultState();

--- a/public/AstroCats3/scripts/app.source.js
+++ b/public/AstroCats3/scripts/app.source.js
@@ -7286,18 +7286,30 @@ const LOADOUTS_MANAGED_EXTERNALLY = true;
     function createMetaProgressManager({ challengeManager, broadcast } = {}) {
         const META_PROGRESS_VERSION = 1;
 
-        const defaultState = () => ({
-            version: META_PROGRESS_VERSION,
-            achievements: {},
-            communityGoals: COMMUNITY_GOALS.map((goal) => ({
-                id: goal.id,
-                progress: 0,
-                contributions: 0,
-                completedAt: null,
-                lastBroadcastPercent: 0
-            })),
-            streak: { milestonesEarned: [] }
-        });
+        const defaultState = () => {
+            const baseState = {
+                version: META_PROGRESS_VERSION,
+                achievements: {},
+                communityGoals: COMMUNITY_GOALS.map((goal) => ({
+                    id: goal.id,
+                    progress: 0,
+                    contributions: 0,
+                    completedAt: null,
+                    lastBroadcastPercent: 0
+                })),
+                streak: { milestonesEarned: [] }
+            };
+
+            try {
+                baseState.seasonPass = { track: SEASON_PASS_TRACK };
+            } catch (error) {
+                if (!(error instanceof ReferenceError)) {
+                    throw error;
+                }
+            }
+
+            return baseState;
+        };
 
         const buildSafeDefaultState = () => {
             try {


### PR DESCRIPTION
## Summary
- guard the meta progress default state so missing `SEASON_PASS_TRACK` data no longer throws
- mirror the safeguard in the compiled AstroCats3 bundle

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d3c8ae3d208324a22eb03dd6548394