### PR TITLE
Simplify asset loading and ignore build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+.DS_Store
+npm-debug.log*


### PR DESCRIPTION
## Summary
- simplify asset resolution by removing dynamic public manifest logic and directly importing the stylesheet
- streamline mini-game entry and background detection logic to reduce unnecessary runtime work
- add a gitignore so build output and dependencies stay out of version control

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3cb262abc8324826e7e729efd1432