### PR TITLE
Fix stylesheet loading without module import

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Astrocat Lobby</title>
+    <link rel="stylesheet" href="./src/style.css" />
     <link
       rel="icon"
       type="image/svg+xml"

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,3 @@
-import "./style.css";
 
 const backgroundImageUrl = new URL(
   "./assets/LobbyBackground.png",


### PR DESCRIPTION
## Summary
- load the global stylesheet directly from index.html so browsers no longer request it as a module
- keep the JavaScript entry point free of CSS imports to avoid MIME type errors in strict environments

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3cdca43e083248021a05f43616313