### PR TITLE
Fix mini game URL resolution for blank base URIs

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -30,15 +30,35 @@ function readPublicManifestEntry(relativePath) {
   return typeof entry === "string" && entry ? entry : null;
 }
 
+function isResolvableBaseHref(baseHref) {
+  if (typeof baseHref !== "string") {
+    return false;
+  }
+
+  const trimmed = baseHref.trim();
+  if (!trimmed) {
+    return false;
+  }
+
+  if (/^(?:about|blob|data|javascript):/i.test(trimmed)) {
+    return false;
+  }
+
+  return true;
+}
+
 function getDocumentBaseHref() {
   if (typeof document !== "undefined" && typeof document.baseURI === "string") {
-    return document.baseURI;
+    if (isResolvableBaseHref(document.baseURI)) {
+      return document.baseURI;
+    }
   }
 
   if (
     typeof window !== "undefined" &&
     window.location &&
-    typeof window.location.href === "string"
+    typeof window.location.href === "string" &&
+    isResolvableBaseHref(window.location.href)
   ) {
     return window.location.href;
   }


### PR DESCRIPTION
## Summary
- ignore non-navigable document base URIs such as about:blank when resolving public assets
- fall back to the current window location when the document base cannot be used

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3d85286708324b2fcbc789c1a5a0a