### PR TITLE
Fix meta progress season pass guard

### DIFF
--- a/public/AstroCats3/scripts/app.js
+++ b/public/AstroCats3/scripts/app.js
@@ -6759,7 +6759,10 @@ document.addEventListener('DOMContentLoaded', () => {
                 streak: { milestonesEarned: [] }
             };
             try {
-                baseState.seasonPass = { track: SEASON_PASS_TRACK };
+                const track = typeof globalThis !== 'undefined' ? globalThis.SEASON_PASS_TRACK : undefined;
+                if (typeof track !== 'undefined') {
+                    baseState.seasonPass = { track: track };
+                }
             }
             catch (error) {
                 if (!(error instanceof ReferenceError)) {

--- a/public/AstroCats3/scripts/app.source.js
+++ b/public/AstroCats3/scripts/app.source.js
@@ -7301,7 +7301,10 @@ const LOADOUTS_MANAGED_EXTERNALLY = true;
             };
 
             try {
-                baseState.seasonPass = { track: SEASON_PASS_TRACK };
+                const track = typeof globalThis !== 'undefined' ? globalThis.SEASON_PASS_TRACK : undefined;
+                if (typeof track !== 'undefined') {
+                    baseState.seasonPass = { track };
+                }
             } catch (error) {
                 if (!(error instanceof ReferenceError)) {
                     throw error;


### PR DESCRIPTION
## Summary
- avoid referencing SEASON_PASS_TRACK before it exists by reading from globalThis instead
- only populate the season pass field when the track value is available

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d43774499c832481c18a4054e54e4f