### PR TITLE
Guard season pass track lookup

### DIFF
--- a/public/AstroCats3/scripts/app.js
+++ b/public/AstroCats3/scripts/app.js
@@ -6759,7 +6759,11 @@ document.addEventListener('DOMContentLoaded', () => {
                 streak: { milestonesEarned: [] }
             };
             try {
-                const track = typeof globalThis !== 'undefined' ? globalThis.SEASON_PASS_TRACK : undefined;
+                let track = undefined;
+                if (typeof globalThis !== 'undefined') {
+                    const descriptor = Object.getOwnPropertyDescriptor(globalThis, 'SEASON_PASS_TRACK');
+                    track = descriptor && descriptor.value;
+                }
                 if (typeof track !== 'undefined') {
                     baseState.seasonPass = { track: track };
                 }

--- a/public/AstroCats3/scripts/app.source.js
+++ b/public/AstroCats3/scripts/app.source.js
@@ -7301,7 +7301,11 @@ const LOADOUTS_MANAGED_EXTERNALLY = true;
             };
 
             try {
-                const track = typeof globalThis !== 'undefined' ? globalThis.SEASON_PASS_TRACK : undefined;
+                let track = undefined;
+                if (typeof globalThis !== 'undefined') {
+                    const descriptor = Object.getOwnPropertyDescriptor(globalThis, 'SEASON_PASS_TRACK');
+                    track = descriptor && descriptor.value;
+                }
                 if (typeof track !== 'undefined') {
                     baseState.seasonPass = { track };
                 }


### PR DESCRIPTION
## Summary
- Guard access to the optional SEASON_PASS_TRACK global before reading it in the AstroCats meta progress defaults
- Mirror the guard in the unminified source bundle so both builds stay in sync

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d439a17dc883248d303a401834ad1b