### PR TITLE
Guard season pass track lookup

### DIFF
--- a/public/AstroCats3/scripts/app.js
+++ b/public/AstroCats3/scripts/app.js
@@ -6745,6 +6745,24 @@ document.addEventListener('DOMContentLoaded', () => {
     function createMetaProgressManager({ challengeManager, broadcast } = {}) {
         var _a;
         const META_PROGRESS_VERSION = 1;
+        const safeReadSeasonPassTrack = () => {
+            if (typeof globalThis === 'undefined') {
+                return undefined;
+            }
+            try {
+                if (!Object.prototype.hasOwnProperty.call(globalThis, 'SEASON_PASS_TRACK')) {
+                    return undefined;
+                }
+                const descriptor = Object.getOwnPropertyDescriptor(globalThis, 'SEASON_PASS_TRACK');
+                return (descriptor === null || descriptor === void 0 ? void 0 : descriptor.value);
+            }
+            catch (error) {
+                if (error instanceof ReferenceError || (typeof (error === null || error === void 0 ? void 0 : error.message) === 'string' && error.message.includes('SEASON_PASS_TRACK'))) {
+                    return undefined;
+                }
+                throw error;
+            }
+        };
         const defaultState = () => {
             const baseState = {
                 version: META_PROGRESS_VERSION,
@@ -6759,11 +6777,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 streak: { milestonesEarned: [] }
             };
             try {
-                let track = undefined;
-                if (typeof globalThis !== 'undefined') {
-                    const descriptor = Object.getOwnPropertyDescriptor(globalThis, 'SEASON_PASS_TRACK');
-                    track = descriptor && descriptor.value;
-                }
+                const track = safeReadSeasonPassTrack();
                 if (typeof track !== 'undefined') {
                     baseState.seasonPass = { track: track };
                 }

--- a/public/AstroCats3/scripts/app.source.js
+++ b/public/AstroCats3/scripts/app.source.js
@@ -7286,6 +7286,27 @@ const LOADOUTS_MANAGED_EXTERNALLY = true;
     function createMetaProgressManager({ challengeManager, broadcast } = {}) {
         const META_PROGRESS_VERSION = 1;
 
+        const safeReadSeasonPassTrack = () => {
+            if (typeof globalThis === 'undefined') {
+                return undefined;
+            }
+
+            try {
+                if (!Object.prototype.hasOwnProperty.call(globalThis, 'SEASON_PASS_TRACK')) {
+                    return undefined;
+                }
+
+                const descriptor = Object.getOwnPropertyDescriptor(globalThis, 'SEASON_PASS_TRACK');
+                return descriptor?.value;
+            } catch (error) {
+                if (error instanceof ReferenceError || (typeof error?.message === 'string' && error.message.includes('SEASON_PASS_TRACK'))) {
+                    return undefined;
+                }
+
+                throw error;
+            }
+        };
+
         const defaultState = () => {
             const baseState = {
                 version: META_PROGRESS_VERSION,
@@ -7301,11 +7322,8 @@ const LOADOUTS_MANAGED_EXTERNALLY = true;
             };
 
             try {
-                let track = undefined;
-                if (typeof globalThis !== 'undefined') {
-                    const descriptor = Object.getOwnPropertyDescriptor(globalThis, 'SEASON_PASS_TRACK');
-                    track = descriptor && descriptor.value;
-                }
+                const track = safeReadSeasonPassTrack();
+
                 if (typeof track !== 'undefined') {
                     baseState.seasonPass = { track };
                 }


### PR DESCRIPTION
## Summary
- add a safe helper to read the optional `SEASON_PASS_TRACK` global before meta state initialisation
- reuse the helper when building the default meta state so ReferenceErrors are suppressed gracefully

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d43c91495c83249699adf33c2fd3ae