### PR TITLE
Add fallback SEASON_PASS_TRACK global

### DIFF
--- a/public/AstroCats3/index.html
+++ b/public/AstroCats3/index.html
@@ -779,6 +779,42 @@
         </div>
     </div>
     <script>
+        (function ensureSeasonPassTrackGlobal() {
+            const scope = typeof globalThis === 'object' && globalThis
+                ? globalThis
+                : typeof window === 'object'
+                    ? window
+                    : null;
+            if (!scope) {
+                return;
+            }
+            const property = 'SEASON_PASS_TRACK';
+            try {
+                if (!Object.prototype.hasOwnProperty.call(scope, property)) {
+                    Object.defineProperty(scope, property, {
+                        configurable: true,
+                        enumerable: false,
+                        writable: true,
+                        value: null
+                    });
+                }
+            }
+            catch (error) {
+                if (error instanceof ReferenceError) {
+                    try {
+                        scope[property] = scope[property] ?? null;
+                    }
+                    catch (assignmentError) {
+                        if (typeof console !== 'undefined') {
+                            console.warn('Failed to provide fallback season pass track binding.', assignmentError);
+                        }
+                    }
+                }
+                else if (typeof console !== 'undefined') {
+                    console.warn('Encountered an unexpected error while preparing the season pass track binding.', error);
+                }
+            }
+        })();
         window.NYAN_ESCAPE_API_BASE_URL = "https://api.xpal.fun";
     </script>
     <script type="module" src="scripts/app.js"></script>


### PR DESCRIPTION
## Summary
- add a guard script in the mini-game HTML to predefine the SEASON_PASS_TRACK global binding
- keep the existing NYAN escape API base configuration after the new guard
- the guard avoids ReferenceErrors when the game code probes for the season pass track before it is initialised

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d43fb672108324810865ff8f8e6d0e