### PR TITLE
Fix safe access to season pass track binding

### DIFF
--- a/public/AstroCats3/scripts/app.js
+++ b/public/AstroCats3/scripts/app.js
@@ -6750,11 +6750,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 return undefined;
             }
             try {
-                if (!Object.prototype.hasOwnProperty.call(globalThis, 'SEASON_PASS_TRACK')) {
-                    return undefined;
-                }
-                const descriptor = Object.getOwnPropertyDescriptor(globalThis, 'SEASON_PASS_TRACK');
-                return (descriptor === null || descriptor === void 0 ? void 0 : descriptor.value);
+                return globalThis.SEASON_PASS_TRACK;
             }
             catch (error) {
                 if (error instanceof ReferenceError || (typeof (error === null || error === void 0 ? void 0 : error.message) === 'string' && error.message.includes('SEASON_PASS_TRACK'))) {

--- a/public/AstroCats3/scripts/app.source.js
+++ b/public/AstroCats3/scripts/app.source.js
@@ -7292,12 +7292,7 @@ const LOADOUTS_MANAGED_EXTERNALLY = true;
             }
 
             try {
-                if (!Object.prototype.hasOwnProperty.call(globalThis, 'SEASON_PASS_TRACK')) {
-                    return undefined;
-                }
-
-                const descriptor = Object.getOwnPropertyDescriptor(globalThis, 'SEASON_PASS_TRACK');
-                return descriptor?.value;
+                return globalThis.SEASON_PASS_TRACK;
             } catch (error) {
                 if (error instanceof ReferenceError || (typeof error?.message === 'string' && error.message.includes('SEASON_PASS_TRACK'))) {
                     return undefined;


### PR DESCRIPTION
## Summary
- simplify the meta progress manager's season pass reader to directly return the global binding
- ensure the helper gracefully handles ReferenceError while avoiding property descriptor lookups that triggered TDZ errors

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68d445a29d0083248efe0c16a5a8217d