### PR TITLE
Fix safe season pass lookup

### DIFF
--- a/public/AstroCats3/scripts/app.js
+++ b/public/AstroCats3/scripts/app.js
@@ -6750,7 +6750,11 @@ document.addEventListener('DOMContentLoaded', () => {
                 return undefined;
             }
             try {
-                return globalThis.SEASON_PASS_TRACK;
+                if (!Object.prototype.hasOwnProperty.call(globalThis, 'SEASON_PASS_TRACK')) {
+                    return undefined;
+                }
+                const descriptor = Object.getOwnPropertyDescriptor(globalThis, 'SEASON_PASS_TRACK');
+                return descriptor === null || descriptor === void 0 ? void 0 : descriptor.value;
             }
             catch (error) {
                 if (error instanceof ReferenceError || (typeof (error === null || error === void 0 ? void 0 : error.message) === 'string' && error.message.includes('SEASON_PASS_TRACK'))) {

--- a/public/AstroCats3/scripts/app.source.js
+++ b/public/AstroCats3/scripts/app.source.js
@@ -7292,7 +7292,13 @@ const LOADOUTS_MANAGED_EXTERNALLY = true;
             }
 
             try {
-                return globalThis.SEASON_PASS_TRACK;
+                if (!Object.prototype.hasOwnProperty.call(globalThis, 'SEASON_PASS_TRACK')) {
+                    return undefined;
+                }
+
+                const descriptor = Object.getOwnPropertyDescriptor(globalThis, 'SEASON_PASS_TRACK');
+
+                return descriptor?.value;
             } catch (error) {
                 if (error instanceof ReferenceError || (typeof error?.message === 'string' && error.message.includes('SEASON_PASS_TRACK'))) {
                     return undefined;


### PR DESCRIPTION
## Summary
- read the optional `SEASON_PASS_TRACK` binding using `Object.getOwnPropertyDescriptor` to avoid triggering temporal dead zones
- maintain the same guarded lookup in both the readable and compiled Astro Cats bundles

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68d44d4bb6cc832496af2e4f1f0ffea2