### PR TITLE
Adjust lobby background scaling and player sprite lighting

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -3338,7 +3338,34 @@ function render(timestamp) {
   );
 
   if (backgroundReady) {
-    ctx.drawImage(backgroundImage, 0, 0, viewport.width, viewport.height);
+    ctx.fillStyle = getFallbackBackgroundGradient();
+    ctx.fillRect(0, 0, viewport.width, viewport.height);
+
+    const sourceWidth = backgroundImage.naturalWidth || backgroundImage.width;
+    const sourceHeight = backgroundImage.naturalHeight || backgroundImage.height;
+
+    if (sourceWidth > 0 && sourceHeight > 0) {
+      const imageAspect = sourceWidth / sourceHeight;
+      const viewportAspect = viewport.width / viewport.height;
+
+      let drawWidth = viewport.width;
+      let drawHeight = viewport.height;
+
+      if (imageAspect > viewportAspect) {
+        drawHeight = viewport.height;
+        drawWidth = drawHeight * imageAspect;
+      } else {
+        drawWidth = viewport.width;
+        drawHeight = drawWidth / imageAspect;
+      }
+
+      const offsetX = (viewport.width - drawWidth) / 2;
+      const offsetY = (viewport.height - drawHeight) / 2;
+
+      ctx.drawImage(backgroundImage, offsetX, offsetY, drawWidth, drawHeight);
+    } else {
+      ctx.drawImage(backgroundImage, 0, 0, viewport.width, viewport.height);
+    }
   } else {
     ctx.fillStyle = getFallbackBackgroundGradient();
     ctx.fillRect(0, 0, viewport.width, viewport.height);
@@ -3492,22 +3519,6 @@ function drawPlayer(entity, time) {
       entity.width,
       entity.height
     );
-
-    ctx.save();
-    ctx.globalCompositeOperation = "source-atop";
-
-    ctx.globalAlpha = 0.28;
-    ctx.fillStyle = appearance.hair;
-    ctx.fillRect(0, 0, entity.width, entity.height * 0.28);
-
-    ctx.globalAlpha = 0.2;
-    ctx.fillStyle = appearance.skin;
-    ctx.fillRect(entity.width * 0.18, entity.height * 0.04, entity.width * 0.64, entity.height * 0.34);
-
-    ctx.globalAlpha = 0.24;
-    ctx.fillStyle = appearance.shirt;
-    ctx.fillRect(0, entity.height * 0.32, entity.width, entity.height * 0.68);
-    ctx.restore();
   } else {
     ctx.fillStyle = appearance.shirt;
     drawRoundedRect(4, 12, entity.width - 8, entity.height - 18, 6);


### PR DESCRIPTION
## Summary
- stop tinting player sprites after drawing to remove the artificial glow effect
- render the lobby background with preserved aspect ratio so it no longer stretches across the canvas
- fall back to the existing gradient behind the background art to avoid empty bars when letterboxed

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d44ea8c57c83248f99f457d64422fe