### PR TITLE
Remove season pass track handling

### DIFF
--- a/public/AstroCats3/index.html
+++ b/public/AstroCats3/index.html
@@ -779,42 +779,6 @@
         </div>
     </div>
     <script>
-        (function ensureSeasonPassTrackGlobal() {
-            const scope = typeof globalThis === 'object' && globalThis
-                ? globalThis
-                : typeof window === 'object'
-                    ? window
-                    : null;
-            if (!scope) {
-                return;
-            }
-            const property = 'SEASON_PASS_TRACK';
-            try {
-                if (!Object.prototype.hasOwnProperty.call(scope, property)) {
-                    Object.defineProperty(scope, property, {
-                        configurable: true,
-                        enumerable: false,
-                        writable: true,
-                        value: null
-                    });
-                }
-            }
-            catch (error) {
-                if (error instanceof ReferenceError) {
-                    try {
-                        scope[property] = scope[property] ?? null;
-                    }
-                    catch (assignmentError) {
-                        if (typeof console !== 'undefined') {
-                            console.warn('Failed to provide fallback season pass track binding.', assignmentError);
-                        }
-                    }
-                }
-                else if (typeof console !== 'undefined') {
-                    console.warn('Encountered an unexpected error while preparing the season pass track binding.', error);
-                }
-            }
-        })();
         window.NYAN_ESCAPE_API_BASE_URL = "https://api.xpal.fun";
     </script>
     <script type="module" src="scripts/app.js"></script>

--- a/public/AstroCats3/scripts/app.js
+++ b/public/AstroCats3/scripts/app.js
@@ -6745,26 +6745,8 @@ document.addEventListener('DOMContentLoaded', () => {
     function createMetaProgressManager({ challengeManager, broadcast } = {}) {
         var _a;
         const META_PROGRESS_VERSION = 1;
-        const safeReadSeasonPassTrack = () => {
-            if (typeof globalThis === 'undefined') {
-                return undefined;
-            }
-            try {
-                if (!Object.prototype.hasOwnProperty.call(globalThis, 'SEASON_PASS_TRACK')) {
-                    return undefined;
-                }
-                const descriptor = Object.getOwnPropertyDescriptor(globalThis, 'SEASON_PASS_TRACK');
-                return descriptor === null || descriptor === void 0 ? void 0 : descriptor.value;
-            }
-            catch (error) {
-                if (error instanceof ReferenceError || (typeof (error === null || error === void 0 ? void 0 : error.message) === 'string' && error.message.includes('SEASON_PASS_TRACK'))) {
-                    return undefined;
-                }
-                throw error;
-            }
-        };
         const defaultState = () => {
-            const baseState = {
+            return {
                 version: META_PROGRESS_VERSION,
                 achievements: {},
                 communityGoals: COMMUNITY_GOALS.map((goal) => ({
@@ -6776,29 +6758,9 @@ document.addEventListener('DOMContentLoaded', () => {
                 })),
                 streak: { milestonesEarned: [] }
             };
-            try {
-                const track = safeReadSeasonPassTrack();
-                if (typeof track !== 'undefined') {
-                    baseState.seasonPass = { track: track };
-                }
-            }
-            catch (error) {
-                if (!(error instanceof ReferenceError)) {
-                    throw error;
-                }
-            }
-            return baseState;
         };
         const buildSafeDefaultState = () => {
-            try {
-                return defaultState();
-            }
-            catch (error) {
-                if (error instanceof ReferenceError) {
-                    return null;
-                }
-                throw error;
-            }
+            return defaultState();
         };
         function ensureCommunityEntry(state, goalId) {
             let entry = Array.isArray(state.communityGoals)

--- a/public/AstroCats3/scripts/app.source.js
+++ b/public/AstroCats3/scripts/app.source.js
@@ -7286,30 +7286,8 @@ const LOADOUTS_MANAGED_EXTERNALLY = true;
     function createMetaProgressManager({ challengeManager, broadcast } = {}) {
         const META_PROGRESS_VERSION = 1;
 
-        const safeReadSeasonPassTrack = () => {
-            if (typeof globalThis === 'undefined') {
-                return undefined;
-            }
-
-            try {
-                if (!Object.prototype.hasOwnProperty.call(globalThis, 'SEASON_PASS_TRACK')) {
-                    return undefined;
-                }
-
-                const descriptor = Object.getOwnPropertyDescriptor(globalThis, 'SEASON_PASS_TRACK');
-
-                return descriptor?.value;
-            } catch (error) {
-                if (error instanceof ReferenceError || (typeof error?.message === 'string' && error.message.includes('SEASON_PASS_TRACK'))) {
-                    return undefined;
-                }
-
-                throw error;
-            }
-        };
-
         const defaultState = () => {
-            const baseState = {
+            return {
                 version: META_PROGRESS_VERSION,
                 achievements: {},
                 communityGoals: COMMUNITY_GOALS.map((goal) => ({
@@ -7321,31 +7299,10 @@ const LOADOUTS_MANAGED_EXTERNALLY = true;
                 })),
                 streak: { milestonesEarned: [] }
             };
-
-            try {
-                const track = safeReadSeasonPassTrack();
-
-                if (typeof track !== 'undefined') {
-                    baseState.seasonPass = { track };
-                }
-            } catch (error) {
-                if (!(error instanceof ReferenceError)) {
-                    throw error;
-                }
-            }
-
-            return baseState;
         };
 
         const buildSafeDefaultState = () => {
-            try {
-                return defaultState();
-            } catch (error) {
-                if (error instanceof ReferenceError) {
-                    return null;
-                }
-                throw error;
-            }
+            return defaultState();
         };
 
         function ensureCommunityEntry(state, goalId) {


### PR DESCRIPTION
## Summary
- remove the season pass track global shim from the AstroCats3 lobby page
- simplify the meta progress manager defaults now that the season pass track is unused

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d455e278d08324863c7e6ca08cffcc