### PR TITLE
Bump service worker cache version to refresh assets

### DIFF
--- a/public/AstroCats3/service-worker.js
+++ b/public/AstroCats3/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = 'flyin-nyan-v1';
+const CACHE_VERSION = 'flyin-nyan-v2';
 const PRECACHE_PATHS = [
   './',
   'index.html',


### PR DESCRIPTION
## Summary
- bump the service worker cache version so browsers fetch the refreshed lobby bundle

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d469643c54832486ec28e33dc933ef