### PR TITLE
Bust cached app.js by versioning script reference

### DIFF
--- a/public/AstroCats3/index.html
+++ b/public/AstroCats3/index.html
@@ -781,7 +781,7 @@
     <script>
         window.NYAN_ESCAPE_API_BASE_URL = "https://api.xpal.fun";
     </script>
-    <script type="module" src="scripts/app.js"></script>
+    <script type="module" src="scripts/app.js?v=20240911"></script>
 
 </body>
 </html>

--- a/public/AstroCats3/service-worker.js
+++ b/public/AstroCats3/service-worker.js
@@ -1,10 +1,10 @@
-const CACHE_VERSION = 'flyin-nyan-v2';
+const CACHE_VERSION = 'flyin-nyan-v3';
 const PRECACHE_PATHS = [
   './',
   'index.html',
   'manifest.webmanifest',
   'styles/main.css',
-  'scripts/app.js',
+  'scripts/app.js?v=20240911',
   'assets/logo.png',
   'assets/background.png',
   'assets/background1.png',


### PR DESCRIPTION
## Summary
- load the game bundle through a versioned URL so browsers bypass any cached copies
- bump the service worker cache version and precache list to match the new bundle path

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d46ffbb67083248da4024fe6cb602c