### PR TITLE
Fix AstroCats3 loadout flag hoisting

### DIFF
--- a/public/AstroCats3/scripts/app.js
+++ b/public/AstroCats3/scripts/app.js
@@ -29,6 +29,7 @@ let preflightSwapWeaponButton = null;
 let openWeaponSelectButton = null;
 const weaponPatternStates = new Map();
 const weaponLoadouts = {};
+const LOADOUTS_MANAGED_EXTERNALLY = true;
 const serviceWorkerSupported = typeof window !== 'undefined' &&
     'serviceWorker' in navigator &&
     typeof ((_a = navigator.serviceWorker) === null || _a === void 0 ? void 0 : _a.register) === 'function';
@@ -3822,7 +3823,6 @@ document.addEventListener('DOMContentLoaded', () => {
         { slot: 'slotB', defaultName: 'Custom Loadout B' }
     ];
     const MAX_LOADOUT_NAME_LENGTH = 32;
-    const LOADOUTS_MANAGED_EXTERNALLY = true;
     function sanitizeLoadoutName(name, fallback) {
         const base = typeof name === 'string' ? name.trim() : '';
         if (!base) {

--- a/public/AstroCats3/scripts/app.source.js
+++ b/public/AstroCats3/scripts/app.source.js
@@ -20,6 +20,8 @@ const weaponPatternStates = new Map();
 
 const weaponLoadouts = {};
 
+const LOADOUTS_MANAGED_EXTERNALLY = true;
+
 const serviceWorkerSupported =
     typeof window !== 'undefined' &&
     'serviceWorker' in navigator &&
@@ -4211,7 +4213,6 @@ const CUSTOM_LOADOUT_SLOTS = [
     { slot: 'slotB', defaultName: 'Custom Loadout B' }
 ];
 const MAX_LOADOUT_NAME_LENGTH = 32;
-const LOADOUTS_MANAGED_EXTERNALLY = true;
 
     function sanitizeLoadoutName(name, fallback) {
         const base = typeof name === 'string' ? name.trim() : '';


### PR DESCRIPTION
## Summary
- hoist the `LOADOUTS_MANAGED_EXTERNALLY` guard in the AstroCats3 source so it is defined before any early references
- regenerate the transpiled mini-game bundle so the runtime fix ships with the build

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d477a76120832485716e1b7b86921c