### PR TITLE
Synchronize lobby level with mini game UI

### DIFF
--- a/public/AstroCats3/index.html
+++ b/public/AstroCats3/index.html
@@ -118,6 +118,14 @@
                 <h2 class="card-title">Flight Status</h2>
                 <div class="stat-list" role="presentation">
                     <div class="stat-row">
+                        <span class="stat-label">Pilot Level</span>
+                        <span class="value" id="pilotLevel">—</span>
+                    </div>
+                    <div class="stat-row">
+                        <span class="stat-label">EXP</span>
+                        <span class="value" id="pilotExp">—</span>
+                    </div>
+                    <div class="stat-row">
                         <span class="stat-label">Score</span>
                         <span class="value" id="score">0</span>
                     </div>

--- a/public/AstroCats3/scripts/app.js
+++ b/public/AstroCats3/scripts/app.js
@@ -2137,6 +2137,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const mcapEl = document.getElementById('mcap');
     const volEl = document.getElementById('vol');
     const powerUpsEl = document.getElementById('powerUps');
+    const pilotLevelEl = document.getElementById('pilotLevel');
+    const pilotExpEl = document.getElementById('pilotExp');
     const comboFillEl = document.getElementById('comboFill');
     const comboMeterEl = document.getElementById('comboMeter');
     const joystickZone = document.getElementById('joystickZone');
@@ -2151,6 +2153,54 @@ document.addEventListener('DOMContentLoaded', () => {
             ratio: debugOverlayEl.querySelector('[data-debug-line="ratio"]')
         }
         : {};
+    const pilotProgressState = {
+        level: null,
+        exp: null,
+        maxExp: null,
+        rank: null
+    };
+    function syncPilotTelemetry() {
+        if (pilotLevelEl) {
+            if (Number.isFinite(pilotProgressState.level)) {
+                const levelText = `Level ${pilotProgressState.level}`;
+                pilotLevelEl.textContent = pilotProgressState.rank
+                    ? `${levelText} — ${pilotProgressState.rank}`
+                    : levelText;
+            }
+            else {
+                pilotLevelEl.textContent = '—';
+            }
+        }
+        if (pilotExpEl) {
+            if (Number.isFinite(pilotProgressState.exp) && Number.isFinite(pilotProgressState.maxExp) && pilotProgressState.maxExp > 0) {
+                const expValue = Math.max(0, Math.floor(pilotProgressState.exp));
+                const maxValue = Math.max(0, Math.floor(pilotProgressState.maxExp));
+                pilotExpEl.textContent = `${expValue.toLocaleString()} / ${maxValue.toLocaleString()}`;
+            }
+            else {
+                pilotExpEl.textContent = '—';
+            }
+        }
+    }
+    function applySharedProfile(partial = {}) {
+        if (partial && typeof partial === 'object') {
+            if (Number.isFinite(partial.level)) {
+                pilotProgressState.level = Math.max(1, Math.floor(partial.level));
+            }
+            if (Number.isFinite(partial.exp)) {
+                pilotProgressState.exp = Math.max(0, partial.exp);
+            }
+            if (Number.isFinite(partial.maxExp)) {
+                pilotProgressState.maxExp = Math.max(0, partial.maxExp);
+            }
+            if (typeof partial.rank === 'string') {
+                const trimmedRank = partial.rank.trim();
+                pilotProgressState.rank = trimmedRank.length ? trimmedRank : null;
+            }
+        }
+        syncPilotTelemetry();
+    }
+    applySharedProfile();
     const overlay = document.getElementById('overlay');
     const overlayMessage = document.getElementById('overlayMessage');
     const flyNowButton = document.getElementById('flyNowButton');
@@ -7487,6 +7537,27 @@ document.addEventListener('DOMContentLoaded', () => {
         }
         if (typeof data.playerName === 'string') {
             updatePlayerName(data.playerName);
+        }
+        const profileUpdate = {};
+        let hasUpdate = false;
+        if (Number.isFinite(data.level)) {
+            profileUpdate.level = data.level;
+            hasUpdate = true;
+        }
+        if (Number.isFinite(data.exp)) {
+            profileUpdate.exp = data.exp;
+            hasUpdate = true;
+        }
+        if (Number.isFinite(data.maxExp)) {
+            profileUpdate.maxExp = data.maxExp;
+            hasUpdate = true;
+        }
+        if (typeof data.rank === 'string') {
+            profileUpdate.rank = data.rank;
+            hasUpdate = true;
+        }
+        if (hasUpdate) {
+            applySharedProfile(profileUpdate);
         }
         // Future profile fields (cosmetics, difficulty, etc.) can be handled here.
     });


### PR DESCRIPTION
## Summary
- display the player's lobby level and EXP inside the mini game stats panel
- sync the mini game profile listener with lobby updates so level, rank, and EXP stay aligned
- add telemetry helpers that format the shared progression data safely

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4f54de8f8832484873675b1faaa4e