### PR TITLE
Move mini game loadout management into lobby

### DIFF
--- a/public/AstroCats3/index.html
+++ b/public/AstroCats3/index.html
@@ -111,7 +111,6 @@
             <button type="button" class="instruction-button" data-panel-target="stats">Flight Status</button>
             <button type="button" class="instruction-button" data-panel-target="missionCard">Mission</button>
             <button type="button" class="instruction-button" data-panel-target="intelCard">Intel</button>
-            <button type="button" class="instruction-button" data-panel-target="loadoutCard">Loadout</button>
         </div>
         <div id="instructionPanels" hidden aria-hidden="true">
             <section id="stats" class="info-panel telemetry-panel" role="complementary" aria-live="polite">
@@ -305,17 +304,6 @@
                     <ul class="intel-log" id="intelLog" role="list" aria-live="polite"></ul>
                 </div>
             </section>
-            <section class="hud-card info-panel" id="loadoutCard" aria-labelledby="loadoutCardTitle">
-                <h2 class="card-title" id="loadoutCardTitle">Custom Loadouts</h2>
-                <div class="card-body">
-                    <p class="custom-loadout-description">
-                        Loadouts are now configured from the Astrocat Lobby. Review the presets you saved there before launch and hop in when you are ready.
-                    </p>
-                    <div class="custom-loadout-section" id="customLoadoutSection" aria-live="polite">
-                        <div class="custom-loadout-grid" data-loadout-grid role="list"></div>
-                    </div>
-                </div>
-            </section>
         </div>
         <div
             id="infoModal"
@@ -390,7 +378,7 @@
             <div id="pilotPreview" aria-live="polite">
                 <div class="pilot-preview-header">
                     <h2>Custom Loadouts</h2>
-                    <p id="pilotPreviewDescription">Equip one of your saved presets instantly before launch. Manage the presets in the Custom Loadouts panel below.</p>
+                    <p id="pilotPreviewDescription">Equip one of your saved presets instantly before launch. Manage your presets from the Astrocat Lobby before stepping into the Starcade.</p>
                 </div>
                 <div id="pilotPreviewGrid" class="pilot-preview-grid" role="list"></div>
             </div>

--- a/public/AstroCats3/scripts/app.js
+++ b/public/AstroCats3/scripts/app.js
@@ -2172,7 +2172,9 @@ document.addEventListener('DOMContentLoaded', () => {
             }
         }
         if (pilotExpEl) {
-            if (Number.isFinite(pilotProgressState.exp) && Number.isFinite(pilotProgressState.maxExp) && pilotProgressState.maxExp > 0) {
+            if (Number.isFinite(pilotProgressState.exp) &&
+                Number.isFinite(pilotProgressState.maxExp) &&
+                pilotProgressState.maxExp > 0) {
                 const expValue = Math.max(0, Math.floor(pilotProgressState.exp));
                 const maxValue = Math.max(0, Math.floor(pilotProgressState.maxExp));
                 pilotExpEl.textContent = `${expValue.toLocaleString()} / ${maxValue.toLocaleString()}`;
@@ -2567,7 +2569,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const pilotPreviewGrid = document.getElementById('pilotPreviewGrid');
     const pilotPreviewDescription = document.getElementById('pilotPreviewDescription');
     const defaultPilotPreviewDescription = ((_l = pilotPreviewDescription === null || pilotPreviewDescription === void 0 ? void 0 : pilotPreviewDescription.textContent) !== null && _l !== void 0 ? _l : '').trim() ||
-        'Presets sync from the Astrocat Lobby. Launch once you are happy with the lobby selection.';
+        'Equip one of your saved presets instantly before launch. Manage your presets from the Astrocat Lobby before stepping into the Starcade.';
     const loadoutCreationPromptText = 'Loadouts are managed in the Astrocat Lobby. Equip a preset there before launch.';
     const shareButton = document.getElementById('shareButton');
     const shareStatusEl = document.getElementById('shareStatus');

--- a/public/AstroCats3/scripts/app.source.js
+++ b/public/AstroCats3/scripts/app.source.js
@@ -2794,7 +2794,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const pilotPreviewDescription = document.getElementById('pilotPreviewDescription');
     const defaultPilotPreviewDescription =
         (pilotPreviewDescription?.textContent ?? '').trim() ||
-        'Presets sync from the Astrocat Lobby. Launch once you are happy with the lobby selection.';
+        'Equip one of your saved presets instantly before launch. Manage your presets from the Astrocat Lobby before stepping into the Starcade.';
     const loadoutCreationPromptText =
         'Loadouts are managed in the Astrocat Lobby. Equip a preset there before launch.';
     const shareButton = document.getElementById('shareButton');


### PR DESCRIPTION
## Summary
- remove the Custom Loadouts instruction tab from the AstroCats3 mini game UI
- update the preflight preview copy to point players back to the lobby for preset management
- regenerate the transpiled mini game bundle with the new messaging

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4f7de9d70832482683ff2248b9195