### PR TITLE
Add toolbar brand image hook

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -299,6 +299,7 @@ const baseCanvasHeight = 540;
 // the gradient page backdrop.
 
 const customPageBackgroundUrl = resolvePublicAssetUrl("webpagebackground.png");
+const toolbarBrandImageUrl = resolvePublicAssetUrl("toolbar-brand.png");
 let customBackgroundAvailabilityProbe = null;
 
 function shouldUseCustomPageBackground() {
@@ -5595,6 +5596,41 @@ function createInterface(stats, options = {}) {
     }
   };
 
+  function attachToolbarBrandImage(brandLink) {
+    if (!brandLink || !toolbarBrandImageUrl) {
+      return null;
+    }
+
+    const image = document.createElement("img");
+    image.className = "site-toolbar__brand-image";
+    image.alt = "";
+    image.setAttribute("aria-hidden", "true");
+    image.decoding = "async";
+    image.loading = "lazy";
+    image.hidden = true;
+
+    const handleLoad = () => {
+      image.hidden = false;
+      brandLink.classList.add("site-toolbar__brand--has-image");
+      image.removeEventListener("load", handleLoad);
+      image.removeEventListener("error", handleError);
+    };
+
+    const handleError = () => {
+      brandLink.classList.remove("site-toolbar__brand--has-image");
+      image.removeEventListener("load", handleLoad);
+      image.removeEventListener("error", handleError);
+      image.remove();
+    };
+
+    image.addEventListener("load", handleLoad);
+    image.addEventListener("error", handleError);
+    image.src = toolbarBrandImageUrl;
+    brandLink.prepend(image);
+
+    return image;
+  }
+
   function createToolbar() {
     const header = document.createElement("header");
     header.className = "site-toolbar";
@@ -5608,11 +5644,17 @@ function createInterface(stats, options = {}) {
     const brandLink = document.createElement("a");
     brandLink.className = "site-toolbar__brand";
     brandLink.href = "#app";
-    brandLink.textContent = "Astrocat Lobby";
     brandLink.setAttribute(
       "aria-label",
       "Return to the top of the Astrocat Lobby"
     );
+
+    const brandText = document.createElement("span");
+    brandText.className = "site-toolbar__brand-text";
+    brandText.textContent = "Astrocat Lobby";
+    brandLink.append(brandText);
+
+    attachToolbarBrandImage(brandLink);
 
     const tagline = document.createElement("span");
     tagline.className = "site-toolbar__tagline";

--- a/src/style.css
+++ b/src/style.css
@@ -101,6 +101,11 @@ body.is-scroll-locked {
   gap: 10px;
 }
 
+.site-toolbar__brand-text {
+  display: inline-flex;
+  align-items: center;
+}
+
 .site-toolbar__brand::before {
   content: "★";
   font-size: 1.1rem;
@@ -109,6 +114,21 @@ body.is-scroll-locked {
     0 0 6px rgba(255, 255, 255, 0.9),
     0 3px 0 rgba(47, 71, 255, 0.45);
   transform: rotate(-12deg);
+}
+
+.site-toolbar__brand--has-image::before {
+  display: none;
+}
+
+.site-toolbar__brand-image {
+  width: 44px;
+  height: 44px;
+  border-radius: 12px;
+  object-fit: contain;
+  box-shadow:
+    0 4px 10px rgba(28, 18, 64, 0.35),
+    inset 0 1px 2px rgba(255, 255, 255, 0.65);
+  background: rgba(255, 255, 255, 0.75);
 }
 
 .site-toolbar__tagline {


### PR DESCRIPTION
## Summary
- allow the lobby toolbar brand to render an optional custom image when available
- ensure the brand text remains accessible and only replaces the decorative star when the image loads successfully
- style the toolbar image so dropped-in PNG assets are framed consistently with the existing design

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d58dc2cbdc8324b9ebd4a515bb852a