### PR TITLE
Improve toolbar responsiveness

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -72,6 +72,7 @@ body.is-scroll-locked {
   border: 3px solid rgba(255, 255, 255, 0.7);
   backdrop-filter: blur(8px);
   color: #2b1645;
+  box-sizing: border-box;
 }
 
 .site-toolbar__inner {
@@ -80,6 +81,8 @@ body.is-scroll-locked {
   justify-content: space-between;
   gap: 24px;
   flex-wrap: wrap;
+  row-gap: 16px;
+  width: 100%;
 }
 
 .site-toolbar__brand-group {
@@ -99,11 +102,14 @@ body.is-scroll-locked {
   display: inline-flex;
   align-items: center;
   gap: 10px;
+  flex-wrap: wrap;
+  max-width: 100%;
 }
 
 .site-toolbar__brand-text {
   display: inline-flex;
   align-items: center;
+  overflow-wrap: anywhere;
 }
 
 .site-toolbar__brand::before {
@@ -136,12 +142,14 @@ body.is-scroll-locked {
   letter-spacing: 0.12em;
   text-transform: uppercase;
   color: rgba(43, 22, 69, 0.75);
+  overflow-wrap: anywhere;
 }
 
 .site-toolbar__nav {
-  flex: 1 1 auto;
+  flex: 1 1 320px;
   display: flex;
   justify-content: flex-end;
+  min-width: 0;
 }
 
 .site-toolbar__list {
@@ -178,6 +186,10 @@ body.is-scroll-locked {
     transform 0.2s ease,
     box-shadow 0.2s ease,
     background 0.2s ease;
+  flex-wrap: wrap;
+  text-align: center;
+  line-height: 1.3;
+  max-width: 100%;
 }
 
 .site-toolbar__link::after {


### PR DESCRIPTION
## Summary
- allow the toolbar brand and links to wrap so long labels stay inside the HUD pill
- add defensive overflow wrapping and width constraints so the toolbar layout adapts on narrow viewports

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d592857c1c832493a96093c792cce8