### PR TITLE
Center HUD info within astrocat lobby chat board

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -445,6 +445,7 @@ body.is-scroll-locked {
 .chat-board__mascot {
   display: flex;
   align-items: flex-end;
+  justify-content: center;
   gap: 20px;
   border-radius: 32px;
   border: 4px solid #2f47ff;
@@ -464,6 +465,8 @@ body.is-scroll-locked {
     margin 0.6s ease,
     opacity 0.4s ease,
     transform 0.6s cubic-bezier(0.2, 0.8, 0.2, 1);
+  width: min(100%, 620px);
+  margin-inline: auto;
 }
 
 .chat-board__mascot.is-active {
@@ -514,6 +517,12 @@ body.is-scroll-locked {
   font-weight: 700;
   letter-spacing: 0.1em;
   color: rgba(210, 220, 255, 0.88);
+}
+
+.chat-board__empty,
+.chat-board__item {
+  width: min(100%, 620px);
+  margin-inline: auto;
 }
 
 .chat-board__bubble {


### PR DESCRIPTION
## Summary
- center the mission HUD chat bubble by constraining the mascot module width and centering its flex content
- limit chat history and empty states to the same centered width so the HUD text no longer bleeds to the right edge

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5ca5c21308324a4dfdf85938f627d