### PR TITLE
Refine Astrocat profile layout

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -5147,18 +5147,25 @@ function createInterface(stats, options = {}) {
   const accountCard = document.createElement("section");
   accountCard.className = "account-card account-card--empty";
 
+  const accountHeader = document.createElement("div");
+  accountHeader.className = "account-card__header";
+
   const accountHeading = document.createElement("span");
   accountHeading.className = "account-card__title";
   accountHeading.textContent = "Your Astrocat Profile";
-  accountCard.append(accountHeading);
 
-  const accountHandle = document.createElement("p");
-  accountHandle.className = "account-card__handle";
-  accountCard.append(accountHandle);
+  const accountHandle = document.createElement("div");
+  accountHandle.className = "account-card__handle is-placeholder";
+  const accountHandleLabel = document.createElement("span");
+  accountHandleLabel.className = "account-card__handle-label";
+  accountHandleLabel.textContent = "Call sign";
+  const accountHandleValue = document.createElement("span");
+  accountHandleValue.className = "account-card__handle-value";
+  accountHandleValue.textContent = "-----";
+  accountHandle.append(accountHandleLabel, accountHandleValue);
 
-  const accountCatName = document.createElement("p");
-  accountCatName.className = "account-card__cat-name";
-  accountCard.append(accountCatName);
+  accountHeader.append(accountHeading, accountHandle);
+  accountCard.append(accountHeader);
 
   const accountStarter = document.createElement("div");
   accountStarter.className = "account-card__starter";
@@ -5167,11 +5174,14 @@ function createInterface(stats, options = {}) {
   accountStarterImage.alt = "Starter preview";
   const accountStarterInfo = document.createElement("div");
   accountStarterInfo.className = "account-card__starter-info";
+  const accountCatName = document.createElement("p");
+  accountCatName.className = "account-card__cat-name is-placeholder";
+  accountCatName.textContent = "Name your Astrocat to begin your mission.";
   const accountStarterName = document.createElement("span");
   accountStarterName.className = "account-card__starter-name";
   const accountStarterTagline = document.createElement("span");
   accountStarterTagline.className = "account-card__starter-tagline";
-  accountStarterInfo.append(accountStarterName, accountStarterTagline);
+  accountStarterInfo.append(accountCatName, accountStarterName, accountStarterTagline);
   accountStarter.append(accountStarterImage, accountStarterInfo);
   accountCard.append(accountStarter);
 
@@ -6179,8 +6189,10 @@ function createInterface(stats, options = {}) {
 
     if (!account) {
       accountCard.classList.add("account-card--empty");
-      accountHandle.textContent = "Call sign: -----";
+      accountHandle.classList.add("is-placeholder");
+      accountHandleValue.textContent = "-----";
       accountCatName.textContent = "Name your Astrocat to begin your mission.";
+      accountCatName.classList.add("is-placeholder");
       accountStarterImage.src = fallbackStarter.image;
       accountStarterImage.alt = fallbackStarter.name;
       accountStarterName.textContent = fallbackStarter.name;
@@ -6189,11 +6201,25 @@ function createInterface(stats, options = {}) {
       return;
     }
 
-    const resolvedStarter = starterOverride ?? findStarterCharacter(account.starterId);
+    const resolvedStarter =
+      starterOverride ?? findStarterCharacter(account.starterId) ?? fallbackStarter;
     accountCard.classList.remove("account-card--empty");
     const callSignLabel = account.callSign ? `@${account.callSign}` : account.handle;
-    accountHandle.textContent = callSignLabel ? `Call sign: ${callSignLabel}` : "Call sign: -----";
-    accountCatName.textContent = account.catName;
+    if (callSignLabel) {
+      accountHandleValue.textContent = callSignLabel;
+      accountHandle.classList.remove("is-placeholder");
+    } else {
+      accountHandleValue.textContent = "-----";
+      accountHandle.classList.add("is-placeholder");
+    }
+    const displayName = typeof account.catName === "string" ? account.catName.trim() : "";
+    if (displayName) {
+      accountCatName.textContent = displayName;
+      accountCatName.classList.remove("is-placeholder");
+    } else {
+      accountCatName.textContent = "Name your Astrocat to begin your mission.";
+      accountCatName.classList.add("is-placeholder");
+    }
     accountStarterImage.src = resolvedStarter.image;
     accountStarterImage.alt = resolvedStarter.name;
     accountStarterName.textContent = resolvedStarter.name;

--- a/src/style.css
+++ b/src/style.css
@@ -1637,7 +1637,7 @@ body.is-scroll-locked {
 .account-card {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 16px;
   padding: 18px 20px;
   border-radius: 20px;
   background: rgba(255, 255, 255, 0.06);
@@ -1645,19 +1645,65 @@ body.is-scroll-locked {
   box-shadow: none;
 }
 
+.account-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
 .account-card__title {
   font-size: 12px;
   text-transform: uppercase;
   letter-spacing: 0.12em;
   color: rgba(230, 235, 255, 0.55);
+  flex: 1 1 auto;
 }
 
 .account-card__handle {
-  margin: 0;
-  font-size: 15px;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  padding: 6px 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(138, 191, 255, 0.32);
+  background: rgba(138, 191, 255, 0.16);
+  color: rgba(214, 232, 255, 0.85);
+  font-size: 11px;
   font-weight: 600;
-  color: #8abfff;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  line-height: 1.25;
+  margin: 0;
+  max-width: 100%;
+}
+
+.account-card__handle-label {
+  flex: 0 0 auto;
+  color: rgba(214, 232, 255, 0.82);
+}
+
+.account-card__handle-value {
+  flex: 1 1 auto;
+  min-width: 0;
+  font-size: 14px;
+  letter-spacing: 0.04em;
+  text-transform: none;
+  color: #f4f7ff;
+  font-weight: 600;
   overflow-wrap: anywhere;
+}
+
+.account-card__handle.is-placeholder {
+  border-style: dashed;
+  background: rgba(138, 191, 255, 0.08);
+  color: rgba(215, 222, 255, 0.72);
+}
+
+.account-card__handle.is-placeholder .account-card__handle-value {
+  color: inherit;
 }
 
 .account-card__cat-name {
@@ -1669,11 +1715,16 @@ body.is-scroll-locked {
   overflow-wrap: anywhere;
 }
 
+.account-card__cat-name.is-placeholder {
+  font-style: italic;
+  color: rgba(215, 222, 255, 0.7);
+}
+
 .account-card__starter {
-  display: flex;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
   gap: 18px;
   align-items: center;
-  flex-wrap: wrap;
 }
 
 .account-card__starter-image {
@@ -1686,11 +1737,12 @@ body.is-scroll-locked {
   object-fit: cover;
 }
 
+
 .account-card__starter-info {
   display: flex;
   flex-direction: column;
-  gap: 4px;
-  flex: 1 1 160px;
+  gap: 6px;
+  align-items: flex-start;
   min-width: 0;
 }
 
@@ -1708,16 +1760,36 @@ body.is-scroll-locked {
   overflow-wrap: anywhere;
 }
 
+@media (max-width: 520px) {
+  .account-card__starter {
+    grid-template-columns: minmax(0, 1fr);
+    justify-items: center;
+    text-align: center;
+  }
+
+  .account-card__starter-info {
+    align-items: center;
+  }
+
+  .account-card__cat-name,
+  .account-card__starter-name,
+  .account-card__starter-tagline {
+    text-align: center;
+  }
+}
+
+
 .account-card__actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 10px;
   margin-top: 4px;
 }
 
 .account-card__action {
-  flex: 1 1 120px;
-  padding: 9px 16px;
+  width: 100%;
+  min-width: 0;
+  padding: 10px 16px;
   border-radius: 999px;
   border: 1px solid rgba(134, 225, 255, 0.35);
   background: rgba(134, 225, 255, 0.16);
@@ -1757,10 +1829,16 @@ body.is-scroll-locked {
   display: none;
 }
 
-.account-card--empty .account-card__handle,
+.account-card--empty .account-card__handle {
+  border-style: dashed;
+  background: rgba(138, 191, 255, 0.08);
+  color: rgba(215, 222, 255, 0.72);
+}
+
+.account-card--empty .account-card__handle-value,
 .account-card--empty .account-card__cat-name {
   font-style: italic;
-  color: rgba(215, 222, 255, 0.58);
+  color: rgba(215, 222, 255, 0.68);
 }
 
 .instruction-list {


### PR DESCRIPTION
## Summary
- restructure the Astrocat profile card to use a header and dedicated call sign badge for tidy text wrapping
- move the cat name into the starter info block and update account switching logic to toggle placeholder states cleanly
- refresh the profile card styling with responsive grid layout and button spacing so the card stays within the panel on all viewports

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5d569f6b88324aa9c8558777c8497