### PR TITLE
Refine HUD modal layout

### DIFF
--- a/public/AstroCats3/styles/main.css
+++ b/public/AstroCats3/styles/main.css
@@ -1159,7 +1159,51 @@ body.touch-enabled #preflightPrompt .desktop-only {
 }
 
 #intelCard .card-body {
+    display: grid;
+    gap: clamp(16px, 3vw, 24px);
     transition: opacity 220ms ease;
+}
+
+#intelCard .meta-progress-grid {
+    margin-top: 0;
+}
+
+@media (min-width: 960px) {
+    #intelCard .card-body {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        align-items: start;
+    }
+
+    #intelCard .challenge-section,
+    #intelCard .cosmetic-section {
+        grid-column: 1;
+    }
+
+    #intelCard .meta-progress-grid {
+        grid-column: 2;
+        grid-row: 1 / span 2;
+    }
+
+    #intelCard .intel-log {
+        grid-column: 1 / -1;
+    }
+
+    #intelCard .cosmetic-section {
+        margin-bottom: 0;
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 12px 16px;
+    }
+
+    #intelCard .weapon-options {
+        grid-column: 1 / -1;
+    }
+
+    #intelCard .intel-log {
+        display: grid;
+        gap: 12px 18px;
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    }
 }
 
 .challenge-section {
@@ -1769,12 +1813,7 @@ body.touch-enabled #preflightPrompt .desktop-only {
     display: grid;
     gap: 16px;
     margin-top: 24px;
-}
-
-@media (min-width: 960px) {
-    .meta-progress-grid {
-        grid-template-columns: repeat(2, minmax(0, 1fr));
-    }
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
 
 .meta-card {
@@ -4006,7 +4045,7 @@ body.loadout-editor-open {
 
 .info-modal-content {
     width: min(960px, 100%);
-    max-height: min(80vh, 880px);
+    max-height: min(88vh, 920px);
     background: linear-gradient(165deg, rgba(15, 23, 42, 0.95), rgba(8, 16, 32, 0.88));
     border-radius: 20px;
     border: 1px solid rgba(148, 163, 184, 0.22);


### PR DESCRIPTION
## Summary
- reorganize the Tactical Intel HUD card into a responsive grid so the challenge, cosmetic, and intel sections sit side by side on wide screens
- let meta-progress tiles and intel log entries auto-fit into compact grids and raise the modal height cap to reduce scrolling overflow

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5e16cc7e48324a3b502c51d411ca0