### PR TITLE
Allow HUD to scroll vertically

### DIFF
--- a/public/AstroCats3/styles/main.css
+++ b/public/AstroCats3/styles/main.css
@@ -46,7 +46,8 @@ body {
     padding: var(--shell-padding);
     font-family: var(--primary-font-stack);
     color: #fff;
-    overflow: hidden;
+    overflow-x: hidden;
+    overflow-y: auto;
     position: relative;
     gap: var(--shell-padding);
     -webkit-tap-highlight-color: transparent;


### PR DESCRIPTION
## Summary
- allow the lobby HUD to scroll vertically by letting the page overflow on the y-axis

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d5f0a6a7c88324bdf54b94cb6f552a