### PR TITLE
Sync lobby progression stats with mini game display

### DIFF
--- a/public/AstroCats3/index.html
+++ b/public/AstroCats3/index.html
@@ -125,6 +125,10 @@
                         <span class="value" id="pilotExp">—</span>
                     </div>
                     <div class="stat-row">
+                        <span class="stat-label">Stat Points</span>
+                        <span class="value" id="pilotStatPoints">—</span>
+                    </div>
+                    <div class="stat-row">
                         <span class="stat-label">Score</span>
                         <span class="value" id="score">0</span>
                     </div>

--- a/public/AstroCats3/scripts/app.js
+++ b/public/AstroCats3/scripts/app.js
@@ -2139,6 +2139,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const powerUpsEl = document.getElementById('powerUps');
     const pilotLevelEl = document.getElementById('pilotLevel');
     const pilotExpEl = document.getElementById('pilotExp');
+    const pilotStatPointsEl = document.getElementById('pilotStatPoints');
     const comboFillEl = document.getElementById('comboFill');
     const comboMeterEl = document.getElementById('comboMeter');
     const joystickZone = document.getElementById('joystickZone');
@@ -2157,6 +2158,7 @@ document.addEventListener('DOMContentLoaded', () => {
         level: null,
         exp: null,
         maxExp: null,
+        statPoints: null,
         rank: null
     };
     function syncPilotTelemetry() {
@@ -2183,6 +2185,15 @@ document.addEventListener('DOMContentLoaded', () => {
                 pilotExpEl.textContent = '—';
             }
         }
+        if (pilotStatPointsEl) {
+            if (Number.isFinite(pilotProgressState.statPoints)) {
+                const clamped = Math.max(0, Math.floor(pilotProgressState.statPoints));
+                pilotStatPointsEl.textContent = `${clamped.toLocaleString()} pts`;
+            }
+            else {
+                pilotStatPointsEl.textContent = '—';
+            }
+        }
     }
     function applySharedProfile(partial = {}) {
         if (partial && typeof partial === 'object') {
@@ -2194,6 +2205,9 @@ document.addEventListener('DOMContentLoaded', () => {
             }
             if (Number.isFinite(partial.maxExp)) {
                 pilotProgressState.maxExp = Math.max(0, partial.maxExp);
+            }
+            if (Number.isFinite(partial.statPoints)) {
+                pilotProgressState.statPoints = Math.max(0, partial.statPoints);
             }
             if (typeof partial.rank === 'string') {
                 const trimmedRank = partial.rank.trim();
@@ -7552,6 +7566,10 @@ document.addEventListener('DOMContentLoaded', () => {
         }
         if (Number.isFinite(data.maxExp)) {
             profileUpdate.maxExp = data.maxExp;
+            hasUpdate = true;
+        }
+        if (Number.isFinite(data.statPoints)) {
+            profileUpdate.statPoints = data.statPoints;
             hasUpdate = true;
         }
         if (typeof data.rank === 'string') {

--- a/public/AstroCats3/scripts/app.source.js
+++ b/public/AstroCats3/scripts/app.source.js
@@ -2311,6 +2311,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const powerUpsEl = document.getElementById('powerUps');
     const pilotLevelEl = document.getElementById('pilotLevel');
     const pilotExpEl = document.getElementById('pilotExp');
+    const pilotStatPointsEl = document.getElementById('pilotStatPoints');
     const comboFillEl = document.getElementById('comboFill');
     const comboMeterEl = document.getElementById('comboMeter');
     const joystickZone = document.getElementById('joystickZone');
@@ -2330,6 +2331,7 @@ document.addEventListener('DOMContentLoaded', () => {
         level: null,
         exp: null,
         maxExp: null,
+        statPoints: null,
         rank: null
     };
 
@@ -2358,6 +2360,15 @@ document.addEventListener('DOMContentLoaded', () => {
                 pilotExpEl.textContent = '—';
             }
         }
+
+        if (pilotStatPointsEl) {
+            if (Number.isFinite(pilotProgressState.statPoints)) {
+                const clamped = Math.max(0, Math.floor(pilotProgressState.statPoints));
+                pilotStatPointsEl.textContent = `${clamped.toLocaleString()} pts`;
+            } else {
+                pilotStatPointsEl.textContent = '—';
+            }
+        }
     }
 
     function applySharedProfile(partial = {}) {
@@ -2370,6 +2381,9 @@ document.addEventListener('DOMContentLoaded', () => {
             }
             if (Number.isFinite(partial.maxExp)) {
                 pilotProgressState.maxExp = Math.max(0, partial.maxExp);
+            }
+            if (Number.isFinite(partial.statPoints)) {
+                pilotProgressState.statPoints = Math.max(0, partial.statPoints);
             }
             if (typeof partial.rank === 'string') {
                 const trimmedRank = partial.rank.trim();
@@ -8148,6 +8162,10 @@ const MAX_LOADOUT_NAME_LENGTH = 32;
         }
         if (Number.isFinite(data.maxExp)) {
             profileUpdate.maxExp = data.maxExp;
+            hasUpdate = true;
+        }
+        if (Number.isFinite(data.statPoints)) {
+            profileUpdate.statPoints = data.statPoints;
             hasUpdate = true;
         }
         if (typeof data.rank === 'string') {

--- a/src/main.js
+++ b/src/main.js
@@ -2392,7 +2392,8 @@ function syncMiniGameProfile() {
     rank: playerStats.rank,
     exp: playerStats.exp,
     maxExp: playerStats.maxExp,
-    weightedLevel: playerStats.weightedLevel
+    weightedLevel: playerStats.weightedLevel,
+    statPoints: playerStats.statPoints
   };
 
   const activeLoadout = getMiniGameLoadoutBySlot(


### PR DESCRIPTION
## Summary
- send the lobby profile's stat point total to the embedded mini game so it can mirror progression
- expose the new stat point field in the mini game UI and telemetry update pipeline

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d6728057248324ac44bf85ccdc2a85