### PR TITLE
Refactor HUD panel into popup buttons

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -737,6 +737,143 @@ body.is-scroll-locked {
   font-weight: 700;
 }
 
+.hud-panel__hint {
+  margin: 0;
+  color: rgba(229, 235, 255, 0.72);
+  font-weight: 500;
+  font-size: 14px;
+}
+
+.hud-panel__actions {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 16px;
+  width: 100%;
+}
+
+.hud-panel__button {
+  appearance: none;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: linear-gradient(135deg, rgba(48, 76, 168, 0.72), rgba(28, 42, 112, 0.68));
+  color: #f4f6ff;
+  padding: 14px 18px;
+  border-radius: 18px;
+  font-size: 15px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.2s ease;
+  text-shadow: 0 1px 2px rgba(8, 12, 24, 0.45);
+}
+
+.hud-panel__button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 32px rgba(10, 18, 46, 0.35);
+  background: linear-gradient(135deg, rgba(74, 108, 208, 0.8), rgba(36, 58, 140, 0.76));
+}
+
+.hud-panel__button:focus-visible {
+  outline: 2px solid #86e1ff;
+  outline-offset: 3px;
+  box-shadow: 0 0 0 4px rgba(134, 225, 255, 0.2);
+}
+
+.hud-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(6, 10, 26, 0.82);
+  backdrop-filter: blur(18px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 32px 24px;
+  z-index: 220;
+}
+
+.hud-overlay[hidden] {
+  display: none;
+}
+
+.hud-modal {
+  width: min(680px, 100%);
+  max-height: min(88vh, 780px);
+  background: rgba(14, 22, 52, 0.96);
+  border-radius: 24px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  box-shadow: 0 28px 64px rgba(8, 12, 32, 0.6);
+  padding: 28px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  color: #f4f6ff;
+}
+
+.hud-modal__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+}
+
+.hud-modal__title {
+  margin: 0;
+  font-size: 24px;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  color: #fefbff;
+}
+
+.hud-modal__close {
+  appearance: none;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  color: #f4f6ff;
+  border-radius: 999px;
+  padding: 8px 18px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.hud-modal__close:hover {
+  background: rgba(255, 255, 255, 0.16);
+}
+
+.hud-modal__close:focus-visible {
+  outline: 2px solid #86e1ff;
+  outline-offset: 3px;
+  box-shadow: 0 0 0 4px rgba(134, 225, 255, 0.25);
+}
+
+.hud-modal__content {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  padding-right: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.hud-modal__content > * {
+  width: 100%;
+}
+
+@media (max-width: 720px) {
+  .hud-panel__actions {
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  }
+
+  .hud-overlay {
+    padding: 24px 16px;
+  }
+
+  .hud-modal {
+    padding: 24px;
+    border-radius: 20px;
+  }
+}
+
 .player-subtitle {
   margin: 0;
   color: rgba(229, 235, 255, 0.72);


### PR DESCRIPTION
## Summary
- replace the right-hand HUD panel content with console buttons that launch modal popups for each lobby system
- add reusable modal logic with focus management and aria attributes so stats, comms, missions, and controls display in dedicated overlays
- style the new HUD buttons and overlays to match the lobby aesthetic across desktop and mobile

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d67b3745648324ad66704916aee171