### PR TITLE
Show player profile by default

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -5168,7 +5168,8 @@ function createInterface(stats, options = {}) {
 
   const hudHint = document.createElement("p");
   hudHint.className = "hud-panel__hint";
-  hudHint.textContent = "Access lobby systems via the console buttons.";
+  hudHint.textContent =
+    "Your profile is displayed below. Access other lobby systems via the console buttons.";
   panel.append(hudHint);
 
   const hudButtons = document.createElement("div");
@@ -5788,12 +5789,10 @@ function createInterface(stats, options = {}) {
     instructions.append(item);
   }
 
-  registerHudPopup({
-    id: "hud-profile",
-    label: "Profile",
-    title: "Astrocat Profile",
-    nodes: [subtitle, accountCard, crystalsLabel, message]
-  });
+  const profileSection = document.createElement("section");
+  profileSection.className = "hud-panel__profile";
+  profileSection.append(subtitle, accountCard, crystalsLabel, message);
+  panel.insertBefore(profileSection, hudButtons);
 
   registerHudPopup({
     id: "hud-stats",

--- a/src/style.css
+++ b/src/style.css
@@ -751,6 +751,14 @@ body.is-scroll-locked {
   width: 100%;
 }
 
+.hud-panel__profile {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  margin: 24px 0;
+  width: 100%;
+}
+
 .hud-panel__button {
   appearance: none;
   border: 1px solid rgba(255, 255, 255, 0.16);


### PR DESCRIPTION
## Summary
- display the player profile panel directly in the lobby sidebar instead of hiding it behind a modal trigger
- adjust the lobby hint copy to reflect the always-visible profile
- add layout styling for the new profile section in the sidebar

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6be9a61288324b540b384995524a5