### PR TITLE
Fix toolbar positioning

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -57,11 +57,15 @@ body.is-scroll-locked {
   width: 100%;
   display: flex;
   justify-content: center;
+  margin-top: 160px;
 }
 
 .site-toolbar {
-  position: sticky;
+  position: fixed;
   top: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: min(calc(100% - 64px), 1280px);
   z-index: 20;
   padding: 18px 32px;
   border-radius: 999px;
@@ -223,7 +227,12 @@ body.is-scroll-locked {
 @media (max-width: 960px) {
   .site-toolbar {
     top: 12px;
+    width: calc(100% - 32px);
     padding: 16px 24px;
+  }
+
+  .lobby-shell__content {
+    margin-top: 200px;
   }
 
   .site-toolbar__inner {


### PR DESCRIPTION
## Summary
- keep the site toolbar fixed to the top of the viewport and center it within the layout
- add responsive spacing so page content clears the fixed toolbar on desktop and mobile widths

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6bf771d888324b3345c53ecff858f