### PR TITLE
Fix toolbar position so it stays pinned near the top

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -61,10 +61,9 @@ body.is-scroll-locked {
 }
 
 .site-toolbar {
-  position: fixed;
+  position: sticky;
   top: 24px;
-  left: 50%;
-  transform: translateX(-50%);
+  margin: 0 auto;
   width: min(calc(100% - 64px), 1280px);
   z-index: 20;
   padding: 18px 32px;


### PR DESCRIPTION
## Summary
- switch the toolbar container to use sticky positioning so it remains pinned near the top of the viewport
- center the toolbar using automatic horizontal margins instead of transforms

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6c42239c08324a544775b5725e2f8