### PR TITLE
Ensure HUD panel content fits within container

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -714,6 +714,7 @@ body.is-scroll-locked {
   gap: 24px;
   color: #f4f6ff;
   text-align: left;
+  box-sizing: border-box;
 }
 
 @media (max-width: 1100px) {
@@ -822,6 +823,7 @@ body.is-scroll-locked {
   flex-direction: column;
   gap: 18px;
   color: #f4f6ff;
+  box-sizing: border-box;
 }
 
 .hud-modal__header {


### PR DESCRIPTION
## Summary
- add border-box sizing to the HUD stats panel so 100% width includes padding
- ensure HUD modals also use border-box sizing to prevent horizontal overflow on small screens

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6c8c328c88324bfb3c06bc684c873