### PR TITLE
Adjust toolbar to scroll with page

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -61,9 +61,8 @@ body.is-scroll-locked {
 }
 
 .site-toolbar {
-  position: sticky;
-  top: 24px;
-  margin: 0 auto;
+  position: static;
+  margin: 24px auto 0;
   width: min(calc(100% - 64px), 1280px);
   z-index: 20;
   padding: 18px 32px;


### PR DESCRIPTION
## Summary
- remove sticky positioning from the toolbar so it no longer stays visible while scrolling
- add a top margin so the toolbar remains spaced from the page edge

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6cfd6dc148324901be22f0b792ad9