### PR TITLE
Reduce lobby content spacing

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -57,7 +57,7 @@ body.is-scroll-locked {
   width: 100%;
   display: flex;
   justify-content: center;
-  margin-top: 160px;
+  margin-top: 10px;
 }
 
 .site-toolbar {
@@ -230,7 +230,7 @@ body.is-scroll-locked {
   }
 
   .lobby-shell__content {
-    margin-top: 200px;
+    margin-top: 10px;
   }
 
   .site-toolbar__inner {


### PR DESCRIPTION
## Summary
- decrease the top margin above the lobby content so it sits 10px beneath the toolbar across viewports

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6d3e1fa488324a7fe3525e410f98b