### PR TITLE
Allow toolbar brand image to load from AstroCats3 assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ Open the printed local URL in your browser to explore the lobby during developme
 
 Add a `webpagebackground.png` file to the `public/` directory to replace the default gradient backdrop that surrounds the lobby canvas. The image is applied automatically when present and falls back to the gradient when removed.
 
+## Custom toolbar branding
+
+To replace the Astrocat Lobby wordmark in the navigation toolbar, add a `toolbar-brand.png` image to either the `public/` directory or the embedded mini game folder at `public/AstroCats3/`. The lobby prefers the root image when both exist and gracefully falls back to text when no custom graphic is supplied.
+
 ## Embedding the AstroCats3 mini game
 
 1. Copy the production build of the **AstroCats3** mini game into `public/AstroCats3/`, replacing the placeholder `index.html` with your own entry point and keeping all referenced assets alongside it.

--- a/src/main.js
+++ b/src/main.js
@@ -348,7 +348,9 @@ const baseCanvasHeight = 540;
 // the gradient page backdrop.
 
 const customPageBackgroundUrl = resolvePublicAssetUrl("webpagebackground.png");
-const toolbarBrandImageUrl = resolvePublicAssetUrl("toolbar-brand.png");
+const toolbarBrandImageUrl =
+  resolvePublicAssetUrl("toolbar-brand.png") ??
+  resolvePublicAssetUrl("AstroCats3/toolbar-brand.png");
 let customBackgroundAvailabilityProbe = null;
 
 function shouldUseCustomPageBackground() {


### PR DESCRIPTION
## Summary
- attempt to resolve the toolbar brand image from the AstroCats3 folder when the default lookup fails
- document how to customize the toolbar brand image placement in the README

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7086f45c083249ccafeca293598aa