### PR TITLE
Ensure public manifest loads before lobby bootstrap

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -134,7 +134,7 @@ function publicManifestPlugin() {
             tag: "script",
             attrs: { id: "astrocat-public-manifest" },
             children: `window.__ASTROCAT_PUBLIC_MANIFEST__ = ${serialized};`,
-            injectTo: "head"
+            injectTo: "head-prepend"
           }
         ]
       } satisfies import("vite").IndexHtmlTransformResult;


### PR DESCRIPTION
## Summary
- inject the public asset manifest script at the start of the document head so runtime asset resolution runs with the manifest data available

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7466d051c8324a2643b9ed2d5e18d