### PR TITLE
Refine stats overlay layout

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -5455,6 +5455,7 @@ function createInterface(stats, options = {}) {
 
   const statsContainer = document.createElement("div");
   statsContainer.className = "stats-container";
+  statsContainer.classList.add("stats-modal__overview");
 
   const statsSummary = document.createElement("div");
   statsSummary.className = "stats-summary";
@@ -5492,6 +5493,7 @@ function createInterface(stats, options = {}) {
 
   const attributePanel = document.createElement("section");
   attributePanel.className = "attribute-panel";
+  attributePanel.classList.add("stats-modal__allocation");
 
   const attributeHeader = document.createElement("div");
   attributeHeader.className = "attribute-panel__header";
@@ -5855,11 +5857,15 @@ function createInterface(stats, options = {}) {
   profileSection.append(subtitle, accountCard, crystalsLabel, message);
   panel.insertBefore(profileSection, hudButtons);
 
+  const statsModal = document.createElement("div");
+  statsModal.className = "stats-modal";
+  statsModal.append(statsContainer, attributePanel);
+
   registerHudPopup({
     id: "hud-stats",
     label: "Stats",
     title: "Pilot Stats",
-    nodes: [statsContainer, attributePanel]
+    nodes: [statsModal]
   });
 
   registerHudPopup({

--- a/src/style.css
+++ b/src/style.css
@@ -924,15 +924,34 @@ body.is-scroll-locked {
 }
 
 .stats-container {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  display: flex;
+  flex-direction: column;
   gap: 18px;
   width: 100%;
-  align-items: start;
+  align-items: stretch;
 }
 
 .stats-container > * {
   min-width: 0;
+}
+
+.stats-modal {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 24px;
+  width: 100%;
+  align-items: start;
+}
+
+.stats-modal__overview,
+.stats-modal__allocation {
+  min-width: 0;
+}
+
+@media (min-width: 960px) {
+  .stats-modal {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
 }
 
 .stats-summary {
@@ -991,10 +1010,6 @@ body.is-scroll-locked {
 
 @media (max-width: 600px) {
   .stats-summary {
-    grid-template-columns: minmax(0, 1fr);
-  }
-
-  .stats-container {
     grid-template-columns: minmax(0, 1fr);
   }
 }


### PR DESCRIPTION
## Summary
- wrap the stats overview and allocation panels inside a dedicated modal container for cleaner pop-up layout
- update stats styles so progress bars stack neatly and the modal uses a responsive two-column grid on wide screens

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8592b1c848324b0fe329dedd46069