### PR TITLE
Remove colorful glow behind lobby player sprites

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -1269,34 +1269,19 @@ body.is-scroll-locked {
   aspect-ratio: 4 / 3;
   border-radius: 14px;
   border: 1px solid rgba(134, 225, 255, 0.24);
-  background: radial-gradient(
-    circle at 50% 20%,
-    rgba(140, 210, 255, 0.26),
-    rgba(10, 14, 32, 0.9) 70%
-  );
+  background: rgba(10, 14, 32, 0.92);
   display: flex;
   align-items: center;
   justify-content: center;
   overflow: hidden;
   box-shadow:
-    inset 0 0 28px rgba(10, 16, 36, 0.65),
+    inset 0 0 18px rgba(10, 16, 36, 0.55),
     0 12px 24px rgba(8, 12, 28, 0.4);
 }
 
-.loadout-preview__item--pilot .loadout-preview__media {
-  background: radial-gradient(
-    circle at 50% 18%,
-    rgba(255, 198, 255, 0.28),
-    rgba(11, 16, 34, 0.92) 72%
-  );
-}
-
+.loadout-preview__item--pilot .loadout-preview__media,
 .loadout-preview__item--weapon .loadout-preview__media {
-  background: radial-gradient(
-    circle at 50% 26%,
-    rgba(129, 222, 255, 0.3),
-    rgba(8, 13, 33, 0.9) 70%
-  );
+  background: rgba(10, 14, 32, 0.92);
 }
 
 .loadout-preview__image {


### PR DESCRIPTION
## Summary
- replace the lobby loadout preview backgrounds with a flat dark panel to eliminate the glowing halo around player sprites
- reuse the same neutral background for all preview types and soften the inset shadow to avoid colorful bloom

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d85ddb1f588324bd41eeedb840088b