### PR TITLE
Integrate pilot stat bonuses into arcade combat

### DIFF
--- a/src/assets/weapons/nebula-bloom.svg
+++ b/src/assets/weapons/nebula-bloom.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160" role="img" aria-labelledby="title desc">
+  <title id="title">Nebula Bloom Weapon Animation</title>
+  <desc id="desc">A spiral bloom of radiant plasma petals representing an unlockable weapon animation.</desc>
+  <defs>
+    <radialGradient id="bloom-core" cx="50%" cy="50%" r="60%">
+      <stop offset="0%" stop-color="#fff0ff" stop-opacity="0.95" />
+      <stop offset="45%" stop-color="#f58cff" stop-opacity="0.9" />
+      <stop offset="100%" stop-color="#682aff" stop-opacity="0.65" />
+    </radialGradient>
+    <linearGradient id="bloom-trail" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#ffb2ff" stop-opacity="0.7" />
+      <stop offset="100%" stop-color="#3ad6ff" stop-opacity="0.8" />
+    </linearGradient>
+    <filter id="soft-glow" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur stdDeviation="6" result="blur" />
+      <feMerge>
+        <feMergeNode in="blur" />
+        <feMergeNode in="SourceGraphic" />
+      </feMerge>
+    </filter>
+  </defs>
+  <rect width="160" height="160" rx="28" fill="#120c33" opacity="0.9" />
+  <g filter="url(#soft-glow)" transform="translate(80 80)">
+    <circle r="52" fill="url(#bloom-core)" />
+    <g fill="none" stroke-linecap="round">
+      <path d="M0,-44 C24,-32 36,-12 30,8 C18,44 -20,52 -44,22" stroke="url(#bloom-trail)" stroke-width="12" opacity="0.7" />
+      <path d="M0,46 C-22,34 -34,14 -30,-6 C-18,-42 20,-50 44,-20" stroke="#ffe5f8" stroke-width="8" opacity="0.55" />
+      <path d="M-6,-4 C-2,-28 22,-36 38,-24" stroke="#ffd27f" stroke-width="6" opacity="0.65" />
+      <path d="M6,6 C2,30 -24,38 -40,24" stroke="#80fff3" stroke-width="6" opacity="0.55" />
+    </g>
+    <circle r="18" fill="#ffffff" opacity="0.92" />
+    <circle r="10" fill="#ff82fb" opacity="0.85" />
+  </g>
+</svg>

--- a/src/assets/weapons/quasar-lance.svg
+++ b/src/assets/weapons/quasar-lance.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 140" role="img" aria-labelledby="title desc">
+  <title id="title">Quasar Lance Weapon Animation</title>
+  <desc id="desc">A focused quasar beam streaking forward with trailing energy arcs for the unlockable weapon animation.</desc>
+  <defs>
+    <linearGradient id="lance-beam" x1="0%" y1="50%" x2="100%" y2="50%">
+      <stop offset="0%" stop-color="#fffce6" stop-opacity="0.95" />
+      <stop offset="40%" stop-color="#7ff3ff" stop-opacity="0.9" />
+      <stop offset="100%" stop-color="#16a9ff" stop-opacity="0.8" />
+    </linearGradient>
+    <linearGradient id="lance-core" x1="0%" y1="50%" x2="100%" y2="50%">
+      <stop offset="0%" stop-color="#ffd17b" stop-opacity="0.95" />
+      <stop offset="60%" stop-color="#ffffff" stop-opacity="0.95" />
+      <stop offset="100%" stop-color="#a1e8ff" stop-opacity="0.9" />
+    </linearGradient>
+    <filter id="beam-glow" x="-10%" y="-40%" width="140%" height="180%">
+      <feGaussianBlur stdDeviation="7" result="blur" />
+      <feMerge>
+        <feMergeNode in="blur" />
+        <feMergeNode in="SourceGraphic" />
+      </feMerge>
+    </filter>
+  </defs>
+  <rect width="200" height="140" rx="24" fill="#0a1229" opacity="0.95" />
+  <g filter="url(#beam-glow)">
+    <path d="M20 70 L160 44 Q186 50 188 70 Q186 90 160 96 Z" fill="url(#lance-beam)" opacity="0.8" />
+    <path d="M24 70 L156 52 Q176 58 178 70 Q176 82 156 88 Z" fill="url(#lance-core)" />
+  </g>
+  <g stroke-linecap="round" fill="none">
+    <path d="M36 46 C68 24 122 22 162 38" stroke="#4ff1ff" stroke-width="6" opacity="0.5" />
+    <path d="M32 94 C72 112 126 114 168 100" stroke="#ff9df7" stroke-width="6" opacity="0.45" />
+    <path d="M46 62 C94 50 134 50 166 60" stroke="#ffe072" stroke-width="4" opacity="0.6" />
+    <path d="M44 78 C90 88 134 88 170 76" stroke="#7ce3ff" stroke-width="4" opacity="0.55" />
+  </g>
+  <circle cx="26" cy="70" r="18" fill="#fff6db" stroke="#ffe082" stroke-width="3" />
+  <circle cx="26" cy="70" r="9" fill="#ff9e4f" />
+</svg>

--- a/src/style.css
+++ b/src/style.css
@@ -1287,6 +1287,21 @@ body.is-scroll-locked {
   text-transform: uppercase;
 }
 
+.loadout-preview__item.is-locked {
+  border-color: rgba(255, 168, 164, 0.55);
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 210, 210, 0.22),
+    0 0 22px rgba(255, 150, 170, 0.18);
+}
+
+.loadout-preview__item.is-locked .loadout-preview__name {
+  color: #ffc4d6;
+}
+
+.loadout-preview__item.is-locked .loadout-preview__summary {
+  color: rgba(255, 206, 218, 0.85);
+}
+
 .loadout-preview__name {
   margin: 0;
   font-size: 16px;
@@ -1333,6 +1348,11 @@ body.is-scroll-locked {
 
 .loadout-panel__select {
   cursor: pointer;
+}
+
+.loadout-panel__select option.is-locked-option {
+  color: rgba(205, 184, 202, 0.85);
+  font-style: italic;
 }
 
 .loadout-panel__input:focus-visible,


### PR DESCRIPTION
## Summary
- propagate lobby skill and attribute data into the embedded arcade config, scaling movement, dash, power-up, and hyper beam tuning from player stats
- apply skill damage, fire-rate, and pierce bonuses to projectile spawning and collision handling so combat reflects the unlocked perks
- update the profile message bridge to feed skill bonuses to the game and regenerate the transpiled bundle

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d85608d4388324b00779f353697446