### PR TITLE
Add progression skill tree and weapon unlocks

### DIFF
--- a/public/AstroCats3/assets/weapon-cyclone.svg
+++ b/public/AstroCats3/assets/weapon-cyclone.svg
@@ -1,0 +1,15 @@
+<svg width="120" height="120" viewBox="0 0 120 120" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="cycloneGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#bae6fd"/>
+      <stop offset="50%" stop-color="#38bdf8"/>
+      <stop offset="100%" stop-color="#0ea5e9"/>
+    </linearGradient>
+  </defs>
+  <rect width="120" height="120" rx="26" fill="#0f172a"/>
+  <g transform="translate(60 60)">
+    <path d="M-34 -6 C-10 -30 26 -30 34 -6 C40 16 18 32 -4 26 C-26 18 -42 6 -34 -6Z" fill="url(#cycloneGradient)" opacity="0.85"/>
+    <path d="M-20 10 C0 24 28 20 32 4 C36 -12 20 -24 4 -18 C-10 -12 -26 0 -20 10Z" fill="url(#cycloneGradient)" opacity="0.65"/>
+    <circle cx="0" cy="0" r="10" fill="#e0f2fe" opacity="0.9"/>
+  </g>
+</svg>

--- a/public/AstroCats3/assets/weapon-nebula.svg
+++ b/public/AstroCats3/assets/weapon-nebula.svg
@@ -1,0 +1,16 @@
+<svg width="120" height="120" viewBox="0 0 120 120" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="nebulaGradient" cx="50%" cy="50%" r="60%">
+      <stop offset="0%" stop-color="#f472b6" stop-opacity="0.95"/>
+      <stop offset="55%" stop-color="#a855f7" stop-opacity="0.7"/>
+      <stop offset="100%" stop-color="#2563eb" stop-opacity="0.35"/>
+    </radialGradient>
+  </defs>
+  <rect width="120" height="120" rx="26" fill="#130a2c"/>
+  <g transform="translate(60 60)">
+    <ellipse rx="42" ry="30" fill="url(#nebulaGradient)"/>
+    <ellipse rx="22" ry="16" fill="#f9a8d4" opacity="0.45"/>
+    <circle cx="-18" cy="-6" r="8" fill="#fef9c3" opacity="0.7"/>
+    <circle cx="20" cy="10" r="10" fill="#c4b5fd" opacity="0.55"/>
+  </g>
+</svg>

--- a/public/AstroCats3/assets/weapon-quasar.svg
+++ b/public/AstroCats3/assets/weapon-quasar.svg
@@ -1,0 +1,16 @@
+<svg width="120" height="120" viewBox="0 0 120 120" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="quasarGradient" cx="50%" cy="50%" r="55%">
+      <stop offset="0%" stop-color="#facc15" stop-opacity="0.95"/>
+      <stop offset="55%" stop-color="#f97316" stop-opacity="0.75"/>
+      <stop offset="100%" stop-color="#38bdf8" stop-opacity="0.4"/>
+    </radialGradient>
+  </defs>
+  <rect width="120" height="120" rx="26" fill="#1f1726"/>
+  <g transform="translate(60 60)">
+    <g transform="rotate(20)">
+      <path d="M0,-44 L8,-14 L40,-14 L12,6 L24,36 L0,16 L-24,36 L-12,6 L-40,-14 L-8,-14 Z" fill="url(#quasarGradient)"/>
+    </g>
+    <circle cx="0" cy="0" r="12" fill="#fff7cc" opacity="0.9"/>
+  </g>
+</svg>

--- a/public/AstroCats3/index.html
+++ b/public/AstroCats3/index.html
@@ -167,6 +167,13 @@
                 >
                     <div id="comboFill"></div>
                 </div>
+                <section id="skillTree" class="skill-tree" aria-labelledby="skillTreeTitle" hidden>
+                    <div class="skill-tree-header">
+                        <h3 id="skillTreeTitle" class="skill-tree-title">Skill Uplink</h3>
+                        <p id="skillTreeHint" class="skill-tree-hint">Earn EXP in flights to unlock stat points.</p>
+                    </div>
+                    <ul id="skillNodeList" class="skill-node-list" role="list"></ul>
+                </section>
                 <div class="flight-controls-toggle">
                     <button
                         type="button"

--- a/public/AstroCats3/scripts/app.js
+++ b/public/AstroCats3/scripts/app.js
@@ -1,14 +1,3 @@
-var __rest = (this && this.__rest) || function (s, e) {
-    var t = {};
-    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p) && e.indexOf(p) < 0)
-        t[p] = s[p];
-    if (s != null && typeof Object.getOwnPropertySymbols === "function")
-        for (var i = 0, p = Object.getOwnPropertySymbols(s); i < p.length; i++) {
-            if (e.indexOf(p[i]) < 0 && Object.prototype.propertyIsEnumerable.call(s, p[i]))
-                t[p[i]] = s[p[i]];
-        }
-    return t;
-};
 var _a, _b;
 let firstRunExperience = true;
 let quickStartUsed = false;
@@ -30,8 +19,8 @@ let openWeaponSelectButton = null;
 const weaponPatternStates = new Map();
 const weaponLoadouts = {};
 const LOADOUTS_MANAGED_EXTERNALLY = true;
-const ENVIRONMENT_SPACE = 'space';
-const ENVIRONMENT_UNDERWATER = 'underwater';
+const ENVIRONMENT_SPACE = "space";
+const ENVIRONMENT_UNDERWATER = "underwater";
 const environmentPhysicsPresets = {
     [ENVIRONMENT_SPACE]: {
         accelerationMultiplier: 1,
@@ -237,6 +226,125 @@ Object.assign(weaponLoadouts, {
         resetPatternState() { },
         pattern(createProjectile) {
             createProjectile(0, 'lance', { applyLoadoutSpeed: false, audioType: 'lance' });
+        }
+    },
+    cyclone: {
+        id: 'cyclone',
+        name: 'Cyclone Twinstorm',
+        icon: 'assets/weapon-cyclone.svg',
+        rarity: 'legendary',
+        summary: 'Twin plasma ribbons spiral forward and wrap around threats.',
+        description: 'A tournament-grade emitter that spins paired bolts into a corkscrew. Excellent for carving tunnels through dense asteroid formations.',
+        highlights: [
+            'Fires two weaving projectiles that sweep a wide channel.',
+            'Maintains a brisk firing cadence despite the spiral arc.',
+            'Stacks power with strength-focused pilots for consistent pressure.'
+        ],
+        cooldownMultiplier: 0.94,
+        speedMultiplier: 1.08,
+        createPatternState: () => ({ spin: 0 }),
+        resetPatternState() { },
+        pattern(createProjectile, context = {}) {
+            var _a;
+            const state = (_a = context === null || context === void 0 ? void 0 : context.state) !== null && _a !== void 0 ? _a : context;
+            if (state.spin == null) {
+                state.spin = 0;
+            }
+            state.spin += 1;
+            const phase = (state.spin % 360) * (Math.PI / 180);
+            createProjectile(-0.2, 'cyclone', {
+                wavePhase: phase,
+                waveFrequency: 8.2,
+                waveAmplitude: 18,
+                waveDrift: 28,
+                audioType: 'scatter'
+            });
+            createProjectile(0.2, 'cyclone', {
+                wavePhase: phase + Math.PI,
+                waveFrequency: 8.2,
+                waveAmplitude: 18,
+                waveDrift: 28,
+                audioType: 'scatter'
+            });
+        }
+    },
+    nebula: {
+        id: 'nebula',
+        name: 'Nebula Bloom',
+        icon: 'assets/weapon-nebula.svg',
+        rarity: 'legendary',
+        summary: 'Pulsing plasma orbs drift forward and destabilise nearby foes.',
+        description: 'Condenses stellar dust into luminous orbs that pulse with gravitational shear. The slow march belies a devastating area sweep.',
+        highlights: [
+            'Launches dual orbs that pulse outward for reliable lane coverage.',
+            'Innate damage boost makes pickups and bosses melt faster.',
+            'Pairs beautifully with focus-heavy pilots chasing EXP bonuses.'
+        ],
+        cooldownMultiplier: 1.22,
+        speedMultiplier: 0.9,
+        createPatternState: () => ({ step: 0 }),
+        resetPatternState() { },
+        pattern(createProjectile, context = {}) {
+            var _a, _b;
+            const state = (_a = context === null || context === void 0 ? void 0 : context.state) !== null && _a !== void 0 ? _a : context;
+            state.step = ((_b = state.step) !== null && _b !== void 0 ? _b : 0) + 1;
+            const offset = ((state.step % 4) - 1.5) * 16;
+            createProjectile(0, 'nebula', {
+                offsetY: offset,
+                speedMultiplier: 0.94,
+                audioType: 'missile',
+                damage: 2
+            });
+            createProjectile(0, 'nebula', {
+                offsetY: -offset,
+                speedMultiplier: 0.94,
+                audioType: 'missile',
+                damage: 2
+            });
+        }
+    },
+    quasar: {
+        id: 'quasar',
+        name: 'Quasar Singularity',
+        icon: 'assets/weapon-quasar.svg',
+        rarity: 'mythic',
+        summary: 'Charged starbursts that detonate with overwhelming force.',
+        description: 'Harnesses a micro-singularity to fire unstable stars. Each detonation carves a path through elite foes and bosses alike.',
+        highlights: [
+            'High-impact star cores that cleave through shielded enemies.',
+            'Fires in charged bursts—time your volleys for maximum impact.',
+            'Rewarding payoff for resilience-focused pilots holding long combos.'
+        ],
+        cooldownMultiplier: 1.38,
+        speedMultiplier: 1.02,
+        createPatternState: () => ({ charge: 0 }),
+        resetPatternState() { },
+        pattern(createProjectile, context = {}) {
+            var _a, _b;
+            const state = (_a = context === null || context === void 0 ? void 0 : context.state) !== null && _a !== void 0 ? _a : context;
+            state.charge = ((_b = state.charge) !== null && _b !== void 0 ? _b : 0) + 1;
+            createProjectile(0, 'quasar', {
+                audioType: 'lance',
+                damage: 3,
+                life: 2600,
+                speedMultiplier: 1.05
+            });
+            if (state.charge % 3 === 0) {
+                createProjectile(0.14, 'quasar', {
+                    offsetY: 18,
+                    audioType: 'lance',
+                    damage: 3,
+                    life: 2400,
+                    speedMultiplier: 1.04
+                });
+                createProjectile(-0.14, 'quasar', {
+                    offsetY: -18,
+                    audioType: 'lance',
+                    damage: 3,
+                    life: 2400,
+                    speedMultiplier: 1.04
+                });
+            }
         }
     }
 });
@@ -787,7 +895,7 @@ document.addEventListener('DOMContentLoaded', () => {
             blockWhileActive: false,
             repeatPenalty: 0.45
         };
-        const resolveRule = (type) => { var _a; return (Object.assign(Object.assign({}, defaultRule), ((_a = POWER_UP_RULES[type]) !== null && _a !== void 0 ? _a : {}))); };
+        const resolveRule = (type) => { var _a; return ({ ...defaultRule, ...((_a = POWER_UP_RULES[type]) !== null && _a !== void 0 ? _a : {}) }); };
         const countActiveBoosts = () => {
             if (!(state === null || state === void 0 ? void 0 : state.powerUpTimers)) {
                 return 0;
@@ -1662,8 +1770,8 @@ document.addEventListener('DOMContentLoaded', () => {
     };
     let activeTrailStyle = null;
     function sanitizeTrailStyle(id, styleDefinition, fallback = DEFAULT_TRAIL_STYLES[id]) {
-        const base = fallback ? Object.assign({}, fallback) : { id, type: 'dynamic' };
-        const result = Object.assign(Object.assign({}, base), { id });
+        const base = fallback ? { ...fallback } : { id, type: 'dynamic' };
+        const result = { ...base, id };
         const applyPaletteColors = (colors) => {
             const palette = Array.isArray(colors)
                 ? colors
@@ -1794,7 +1902,7 @@ document.addEventListener('DOMContentLoaded', () => {
             return override.trim() || defaultSrc;
         }
         if (typeof override === 'object') {
-            const config = Object.assign({}, override);
+            const config = { ...override };
             if ((!config.src || typeof config.src !== 'string' || !config.src.trim()) && defaultSrc) {
                 config.src = defaultSrc;
             }
@@ -2116,6 +2224,39 @@ document.addEventListener('DOMContentLoaded', () => {
             shadowBlur: 16,
             shadowColor: 'rgba(56, 189, 248, 0.36)'
         },
+        cyclone: {
+            width: 26,
+            height: 18,
+            speedMultiplier: 1.04,
+            life: 2000,
+            damage: 1,
+            gradient: ['#bae6fd', '#38bdf8', '#0ea5e9'],
+            glow: 'rgba(14, 165, 233, 0.52)',
+            shadowBlur: 14,
+            shadowColor: 'rgba(14, 165, 233, 0.32)'
+        },
+        nebula: {
+            width: 34,
+            height: 24,
+            speedMultiplier: 0.92,
+            life: 2600,
+            damage: 2,
+            gradient: ['rgba(236, 72, 153, 0.9)', 'rgba(168, 85, 247, 0.6)', 'rgba(59, 130, 246, 0.25)'],
+            glow: 'rgba(168, 85, 247, 0.55)',
+            shadowBlur: 18,
+            shadowColor: 'rgba(129, 140, 248, 0.32)'
+        },
+        quasar: {
+            width: 30,
+            height: 30,
+            speedMultiplier: 0.96,
+            life: 2400,
+            damage: 3,
+            gradient: ['rgba(253, 230, 138, 0.95)', 'rgba(251, 191, 36, 0.75)', 'rgba(59, 130, 246, 0.28)'],
+            glow: 'rgba(251, 191, 36, 0.6)',
+            shadowBlur: 20,
+            shadowColor: 'rgba(251, 191, 36, 0.4)'
+        },
         flameWhip: {
             width: 48,
             height: 26,
@@ -2171,6 +2312,10 @@ document.addEventListener('DOMContentLoaded', () => {
     const pilotLevelEl = document.getElementById('pilotLevel');
     const pilotExpEl = document.getElementById('pilotExp');
     const pilotStatPointsEl = document.getElementById('pilotStatPoints');
+    const skillTreeSection = document.getElementById('skillTree');
+    const skillTreeListEl = document.getElementById('skillNodeList');
+    const skillTreeHintEl = document.getElementById('skillTreeHint');
+    let skillTreeMessageTimer = null;
     const comboFillEl = document.getElementById('comboFill');
     const comboMeterEl = document.getElementById('comboMeter');
     const joystickZone = document.getElementById('joystickZone');
@@ -2192,6 +2337,88 @@ document.addEventListener('DOMContentLoaded', () => {
         statPoints: null,
         rank: null
     };
+    function renderSkillTreeUI() {
+        var _a, _b, _c;
+        if (!(skillTreeListEl instanceof HTMLElement)) {
+            return;
+        }
+        const state = progressionSystem.getState();
+        const availablePoints = (_a = state === null || state === void 0 ? void 0 : state.statPoints) !== null && _a !== void 0 ? _a : 0;
+        const allocations = (_b = state === null || state === void 0 ? void 0 : state.skillAllocations) !== null && _b !== void 0 ? _b : {};
+        skillTreeListEl.textContent = '';
+        for (const node of SKILL_TREE_NODES) {
+            const rank = (_c = allocations[node.id]) !== null && _c !== void 0 ? _c : 0;
+            const item = document.createElement('li');
+            item.className = 'skill-node';
+            item.dataset.skillId = node.id;
+            if (rank >= node.maxRank) {
+                item.classList.add('maxed');
+            }
+            const header = document.createElement('div');
+            header.className = 'skill-node-header';
+            const title = document.createElement('span');
+            title.className = 'skill-node-name';
+            title.textContent = node.label;
+            const rankEl = document.createElement('span');
+            rankEl.className = 'skill-node-rank';
+            rankEl.textContent = `${rank}/${node.maxRank}`;
+            header.append(title, rankEl);
+            item.appendChild(header);
+            const description = document.createElement('p');
+            description.className = 'skill-node-description';
+            description.textContent = node.description;
+            item.appendChild(description);
+            if (typeof node.effectText === 'function') {
+                const effect = document.createElement('p');
+                effect.className = 'skill-node-effect';
+                effect.textContent = node.effectText(rank);
+                item.appendChild(effect);
+            }
+            const button = document.createElement('button');
+            button.type = 'button';
+            button.className = 'skill-node-upgrade';
+            button.dataset.skillUpgrade = node.id;
+            const isMaxed = rank >= node.maxRank;
+            button.textContent = isMaxed ? 'Maxed' : 'Invest';
+            const shouldDisable = isMaxed || availablePoints <= 0;
+            button.disabled = shouldDisable;
+            button.setAttribute('aria-disabled', shouldDisable ? 'true' : 'false');
+            item.appendChild(button);
+            skillTreeListEl.appendChild(item);
+        }
+        if (skillTreeHintEl instanceof HTMLElement && !skillTreeHintEl.classList.contains('message')) {
+            const available = availablePoints > 0;
+            skillTreeHintEl.textContent = available
+                ? availablePoints === 1
+                    ? '1 point available to invest.'
+                    : `${availablePoints} points available to invest.`
+                : 'Earn EXP in flights to unlock more stat points.';
+            skillTreeHintEl.classList.toggle('available', available);
+            skillTreeHintEl.dataset.status = available ? 'available' : '';
+        }
+        if (skillTreeSection instanceof HTMLElement) {
+            skillTreeSection.hidden = false;
+        }
+    }
+    function showSkillTreeMessage(message, type = 'info') {
+        if (!(skillTreeHintEl instanceof HTMLElement) || !message) {
+            return;
+        }
+        if (skillTreeMessageTimer != null) {
+            window.clearTimeout(skillTreeMessageTimer);
+            skillTreeMessageTimer = null;
+        }
+        skillTreeHintEl.textContent = message;
+        skillTreeHintEl.dataset.status = type;
+        skillTreeHintEl.classList.add('message');
+        skillTreeHintEl.classList.remove('available');
+        skillTreeMessageTimer = window.setTimeout(() => {
+            skillTreeHintEl.classList.remove('message');
+            skillTreeHintEl.dataset.status = '';
+            skillTreeMessageTimer = null;
+            renderSkillTreeUI();
+        }, 4200);
+    }
     function syncPilotTelemetry() {
         if (pilotLevelEl) {
             if (Number.isFinite(pilotProgressState.level)) {
@@ -2246,6 +2473,19 @@ document.addEventListener('DOMContentLoaded', () => {
             }
         }
         syncPilotTelemetry();
+    }
+    function updateProgressionTelemetry() {
+        const state = progressionSystem.getState();
+        if (!state) {
+            return;
+        }
+        applySharedProfile({
+            level: state.level,
+            exp: state.exp,
+            maxExp: getExpRequirement(state.level),
+            statPoints: state.statPoints,
+            rank: getRankLabel(state.level)
+        });
     }
     applySharedProfile();
     const overlay = document.getElementById('overlay');
@@ -2827,24 +3067,25 @@ document.addEventListener('DOMContentLoaded', () => {
         ? performance.now()
         : Date.now();
     function getCurrentEnvironment() {
+        var _a;
         if (state && typeof state === 'object' && typeof state.environment === 'string') {
             return state.environment;
         }
-        return (environmentState && environmentState.current) || ENVIRONMENT_SPACE;
+        return (_a = environmentState.current) !== null && _a !== void 0 ? _a : ENVIRONMENT_SPACE;
     }
     function isUnderwaterEnvironment() {
         return getCurrentEnvironment() === ENVIRONMENT_UNDERWATER;
     }
     function getEnvironmentPhysics(environment = getCurrentEnvironment()) {
-        return environmentPhysicsPresets[environment] || environmentPhysicsPresets[ENVIRONMENT_SPACE];
+        var _a;
+        return (_a = environmentPhysicsPresets[environment]) !== null && _a !== void 0 ? _a : environmentPhysicsPresets[ENVIRONMENT_SPACE];
     }
     function reseedStarsForEnvironment(environment = getCurrentEnvironment()) {
+        var _a;
         if (!Array.isArray(stars) || stars.length === 0) {
             return;
         }
-        const starConfig = config && typeof config === 'object' ? config.star : undefined;
-        const starBase = starConfig && typeof starConfig.baseSpeed === 'number' ? starConfig.baseSpeed : NaN;
-        const baseSpeed = Number.isFinite(starBase) ? starBase : 80;
+        const baseSpeed = Number.isFinite((_a = config === null || config === void 0 ? void 0 : config.star) === null || _a === void 0 ? void 0 : _a.baseSpeed) ? config.star.baseSpeed : 80;
         if (environment === ENVIRONMENT_UNDERWATER) {
             for (const star of stars) {
                 star.speed = (Math.random() * 0.8 + 0.5) * baseSpeed * 0.6;
@@ -2852,7 +3093,8 @@ document.addEventListener('DOMContentLoaded', () => {
                 star.drift = (Math.random() * 18 + 8) * (Math.random() < 0.5 ? -1 : 1);
                 star.rippleOffset = Math.random() * Math.PI * 2;
             }
-        } else {
+        }
+        else {
             for (const star of stars) {
                 star.speed = (Math.random() * 0.8 + 0.4) * baseSpeed;
                 star.size = Math.random() * 2.5 + 0.6;
@@ -2861,8 +3103,7 @@ document.addEventListener('DOMContentLoaded', () => {
             }
         }
     }
-    function setEnvironment(nextEnvironment, options) {
-        const force = (options && options.force) || false;
+    function setEnvironment(nextEnvironment, { force = false } = {}) {
         const normalized = nextEnvironment === ENVIRONMENT_UNDERWATER ? ENVIRONMENT_UNDERWATER : ENVIRONMENT_SPACE;
         const previous = environmentState.current;
         environmentState.current = normalized;
@@ -3932,7 +4173,8 @@ document.addEventListener('DOMContentLoaded', () => {
         challenges: 'nyanEscape.challenges',
         deviceId: 'nyanEscape.deviceId',
         customLoadouts: 'nyanEscape.customLoadouts',
-        metaProgress: 'nyanEscape.metaProgress'
+        metaProgress: 'nyanEscape.metaProgress',
+        progression: 'nyanEscape.progression'
     };
     var storageAvailable = false;
     try {
@@ -3970,6 +4212,442 @@ document.addEventListener('DOMContentLoaded', () => {
             storageAvailable = false;
         }
     }
+    const LEVEL_CAP = 60;
+    const SKILL_TREE_NODES = [
+        {
+            id: 'strength',
+            label: 'Plasma Strength',
+            description: 'Supercharge the ship\'s primary cannons with heavier impact.',
+            maxRank: 12,
+            effectText(rank) {
+                const bonus = Math.round(rank * 6);
+                return `+${bonus}% projectile damage`;
+            }
+        },
+        {
+            id: 'agility',
+            label: 'Velocity Weave',
+            description: 'Tighten reactor timing to reduce weapon cooldowns.',
+            maxRank: 10,
+            effectText(rank) {
+                const bonus = Math.round(rank * 8);
+                return `-${bonus}% firing cooldown`;
+            }
+        },
+        {
+            id: 'focus',
+            label: 'Quantum Focus',
+            description: 'Accelerate bolts and channel additional combat telemetry.',
+            maxRank: 10,
+            effectText(rank) {
+                const speed = Math.round(rank * 5);
+                const exp = Math.round(rank * 3);
+                return `+${speed}% projectile speed, +${exp}% EXP gain`;
+            }
+        },
+        {
+            id: 'resilience',
+            label: 'Flux Shielding',
+            description: 'Stabilise combo timing and amplify score streak payouts.',
+            maxRank: 10,
+            effectText(rank) {
+                const windowBonus = Math.round(rank * 6);
+                const scoreBonus = Math.round(rank * 2);
+                return `+${windowBonus}% combo window, +${scoreBonus}% score`;
+            }
+        }
+    ];
+    const SKILL_NODE_INDEX = new Map(SKILL_TREE_NODES.map((node) => [node.id, node]));
+    const WEAPON_UNLOCK_RULES = [
+        { level: 2, weaponId: 'scatter' },
+        { level: 4, weaponId: 'lance' },
+        { level: 6, weaponId: 'cyclone' },
+        { level: 8, weaponId: 'nebula' },
+        { level: 12, weaponId: 'quasar' }
+    ];
+    function getWeaponUnlockRequirement(weaponId) {
+        const rule = WEAPON_UNLOCK_RULES.find((entry) => entry.weaponId === weaponId);
+        return rule ? rule.level : null;
+    }
+    let progressionState = null;
+    const progressionEffects = {
+        damageMultiplier: 1,
+        projectileSpeedMultiplier: 1,
+        cooldownMultiplier: 1,
+        comboWindowMultiplier: 1,
+        scoreMultiplier: 1,
+        expGainMultiplier: 1
+    };
+    let experienceCarryover = 0;
+    let updateProgressionTelemetryHook = null;
+    let renderSkillTreeHook = null;
+    let skillTreeMessageHook = null;
+    function getExpRequirement(level) {
+        const normalized = Math.max(1, Math.min(LEVEL_CAP, Number.isFinite(level) ? Math.floor(level) : 1));
+        const base = 320;
+        const curve = Math.pow(normalized + 4, 1.6) * 18;
+        return Math.max(120, Math.round(base + curve));
+    }
+    function getRankLabel(level) {
+        if (level >= 40) {
+            return 'Galaxy Legend';
+        }
+        if (level >= 30) {
+            return 'Star Commodore';
+        }
+        if (level >= 20) {
+            return 'Wing Commander';
+        }
+        if (level >= 10) {
+            return 'Squad Ace';
+        }
+        if (level >= 5) {
+            return 'Senior Cadet';
+        }
+        return 'Flight Cadet';
+    }
+    function createDefaultProgressionState() {
+        const allocations = {};
+        for (const node of SKILL_TREE_NODES) {
+            allocations[node.id] = 0;
+        }
+        return {
+            version: 1,
+            level: 1,
+            exp: 0,
+            totalExp: 0,
+            statPoints: 2,
+            skillAllocations: allocations,
+            unlockedWeapons: ['pulse']
+        };
+    }
+    function normalizeProgressionState(raw) {
+        var _a;
+        const defaults = createDefaultProgressionState();
+        if (!raw || typeof raw !== 'object') {
+            return defaults;
+        }
+        const state = {
+            version: 1,
+            level: Number.isFinite(raw.level) ? Math.max(1, Math.min(LEVEL_CAP, Math.floor(raw.level))) : defaults.level,
+            exp: Number.isFinite(raw.exp) ? Math.max(0, Math.floor(raw.exp)) : defaults.exp,
+            totalExp: Number.isFinite(raw.totalExp) ? Math.max(0, Math.floor(raw.totalExp)) : defaults.totalExp,
+            statPoints: Number.isFinite(raw.statPoints) ? Math.max(0, Math.floor(raw.statPoints)) : defaults.statPoints,
+            skillAllocations: { ...defaults.skillAllocations },
+            unlockedWeapons: Array.isArray(raw.unlockedWeapons)
+                ? Array.from(new Set(raw.unlockedWeapons.map((value) => String(value)))).filter(Boolean)
+                : [...defaults.unlockedWeapons]
+        };
+        for (const node of SKILL_TREE_NODES) {
+            const rank = Number.isFinite((_a = raw.skillAllocations) === null || _a === void 0 ? void 0 : _a[node.id])
+                ? Math.max(0, Math.min(node.maxRank, Math.floor(raw.skillAllocations[node.id])))
+                : defaults.skillAllocations[node.id];
+            state.skillAllocations[node.id] = rank;
+        }
+        return state;
+    }
+    function loadProgressionState() {
+        if (!storageAvailable) {
+            return normalizeProgressionState(null);
+        }
+        try {
+            const raw = readStorage(STORAGE_KEYS.progression);
+            if (!raw) {
+                return normalizeProgressionState(null);
+            }
+            const parsed = JSON.parse(raw);
+            return normalizeProgressionState(parsed);
+        }
+        catch (error) {
+            return normalizeProgressionState(null);
+        }
+    }
+    function persistProgressionState() {
+        if (!storageAvailable || !progressionState) {
+            return;
+        }
+        try {
+            const payload = {
+                version: 1,
+                level: progressionState.level,
+                exp: progressionState.exp,
+                totalExp: progressionState.totalExp,
+                statPoints: progressionState.statPoints,
+                skillAllocations: { ...progressionState.skillAllocations },
+                unlockedWeapons: Array.from(new Set(progressionState.unlockedWeapons.map((value) => String(value))))
+            };
+            writeStorage(STORAGE_KEYS.progression, JSON.stringify(payload));
+        }
+        catch (error) {
+            // Ignore persistence errors
+        }
+    }
+    function recalcProgressionEffects() {
+        var _a, _b, _c, _d, _e, _f, _g, _h;
+        const strength = (_b = (_a = progressionState === null || progressionState === void 0 ? void 0 : progressionState.skillAllocations) === null || _a === void 0 ? void 0 : _a.strength) !== null && _b !== void 0 ? _b : 0;
+        const agility = (_d = (_c = progressionState === null || progressionState === void 0 ? void 0 : progressionState.skillAllocations) === null || _c === void 0 ? void 0 : _c.agility) !== null && _d !== void 0 ? _d : 0;
+        const focus = (_f = (_e = progressionState === null || progressionState === void 0 ? void 0 : progressionState.skillAllocations) === null || _e === void 0 ? void 0 : _e.focus) !== null && _f !== void 0 ? _f : 0;
+        const resilience = (_h = (_g = progressionState === null || progressionState === void 0 ? void 0 : progressionState.skillAllocations) === null || _g === void 0 ? void 0 : _g.resilience) !== null && _h !== void 0 ? _h : 0;
+        progressionEffects.damageMultiplier = 1 + strength * 0.06;
+        progressionEffects.cooldownMultiplier = 1 / (1 + agility * 0.08);
+        progressionEffects.projectileSpeedMultiplier = 1 + focus * 0.05;
+        progressionEffects.expGainMultiplier = 1 + focus * 0.03;
+        progressionEffects.comboWindowMultiplier = 1 + resilience * 0.06;
+        progressionEffects.scoreMultiplier = 1 + resilience * 0.02;
+    }
+    function pushSkillTreeMessage(message, type = 'info') {
+        if (typeof skillTreeMessageHook === 'function' && message) {
+            try {
+                skillTreeMessageHook(message, type);
+            }
+            catch (error) {
+                console.error('skill tree message error', error);
+            }
+        }
+    }
+    function syncProgressionToCosmetics({ silent = false } = {}) {
+        if (typeof ensureCosmeticsState !== 'function') {
+            return;
+        }
+        const cosmetics = ensureCosmeticsState();
+        if (!Array.isArray(cosmetics.ownedWeapons)) {
+            cosmetics.ownedWeapons = [];
+        }
+        const ownedSet = new Set(cosmetics.ownedWeapons.map((value) => String(value)));
+        let changed = false;
+        for (const weaponId of progressionState.unlockedWeapons) {
+            if (!ownedSet.has(weaponId)) {
+                cosmetics.ownedWeapons.push(weaponId);
+                ownedSet.add(weaponId);
+                changed = true;
+            }
+        }
+        for (const weaponId of cosmetics.ownedWeapons) {
+            if (!progressionState.unlockedWeapons.includes(weaponId)) {
+                progressionState.unlockedWeapons.push(weaponId);
+                changed = true;
+            }
+        }
+        if (changed && !silent) {
+            persistProgressionState();
+        }
+    }
+    function unlockWeaponsForLevel(level, { announce = false } = {}) {
+        var _a;
+        const unlocked = [];
+        for (const rule of WEAPON_UNLOCK_RULES) {
+            if (level >= rule.level && !progressionState.unlockedWeapons.includes(rule.weaponId)) {
+                progressionState.unlockedWeapons.push(rule.weaponId);
+                unlocked.push(rule.weaponId);
+            }
+        }
+        if (unlocked.length) {
+            syncProgressionToCosmetics({ silent: true });
+            persistProgressionState();
+            if (announce) {
+                for (const weaponId of unlocked) {
+                    const definition = typeof getWeaponDefinition === 'function' ? getWeaponDefinition(weaponId) : null;
+                    const name = (_a = definition === null || definition === void 0 ? void 0 : definition.name) !== null && _a !== void 0 ? _a : weaponId;
+                    pushSkillTreeMessage(`Unlocked weapon: ${name}`, 'success');
+                }
+                try {
+                    if (typeof renderWeaponSelectGrid === 'function') {
+                        renderWeaponSelectGrid();
+                    }
+                }
+                catch (error) {
+                    console.error('weapon grid refresh failed', error);
+                }
+                try {
+                    if (typeof updatePreflightSummary === 'function') {
+                        updatePreflightSummary();
+                    }
+                }
+                catch (error) {
+                    console.error('preflight summary refresh failed', error);
+                }
+            }
+        }
+        return unlocked;
+    }
+    function updateProgressionHooks({ announce = false } = {}) {
+        recalcProgressionEffects();
+        if (typeof updateProgressionTelemetryHook === 'function') {
+            try {
+                updateProgressionTelemetryHook();
+            }
+            catch (error) {
+                console.error('progression telemetry update error', error);
+            }
+        }
+        if (typeof renderSkillTreeHook === 'function') {
+            try {
+                renderSkillTreeHook();
+            }
+            catch (error) {
+                console.error('skill tree render error', error);
+            }
+        }
+        if (announce) {
+            const rank = getRankLabel(progressionState.level);
+            pushSkillTreeMessage(`Level ${progressionState.level} — ${rank}`, 'success');
+        }
+    }
+    function addProgressionExperience(amount, { source = 'score' } = {}) {
+        var _a, _b;
+        const numeric = Number(amount);
+        if (!Number.isFinite(numeric) || numeric <= 0 || !progressionState) {
+            return 0;
+        }
+        const rates = {
+            score: 1 / 28,
+            dodge: 1 / 18,
+            time: 0.08 / 1000,
+            boss: 12
+        };
+        const rate = (_a = rates[source]) !== null && _a !== void 0 ? _a : rates.score;
+        const scaled = numeric * rate * progressionEffects.expGainMultiplier;
+        experienceCarryover += scaled;
+        const whole = Math.floor(experienceCarryover);
+        if (whole <= 0) {
+            return 0;
+        }
+        experienceCarryover -= whole;
+        let remaining = whole;
+        let leveled = false;
+        progressionState.totalExp += whole;
+        while (remaining > 0) {
+            const requirement = getExpRequirement(progressionState.level);
+            const needed = requirement - progressionState.exp;
+            if (remaining >= needed && progressionState.level < LEVEL_CAP) {
+                progressionState.exp = 0;
+                progressionState.level = Math.min(LEVEL_CAP, progressionState.level + 1);
+                progressionState.statPoints += 2;
+                remaining -= needed;
+                leveled = true;
+            }
+            else {
+                progressionState.exp = Math.min(requirement, progressionState.exp + remaining);
+                remaining = 0;
+            }
+            if (progressionState.level >= LEVEL_CAP) {
+                progressionState.exp = Math.min(getExpRequirement(LEVEL_CAP), progressionState.exp);
+                remaining = 0;
+            }
+        }
+        persistProgressionState();
+        const unlocked = unlockWeaponsForLevel(progressionState.level, { announce: leveled });
+        updateProgressionHooks({ announce: leveled });
+        if (!leveled && unlocked.length) {
+            for (const weaponId of unlocked) {
+                const definition = typeof getWeaponDefinition === 'function' ? getWeaponDefinition(weaponId) : null;
+                const name = (_b = definition === null || definition === void 0 ? void 0 : definition.name) !== null && _b !== void 0 ? _b : weaponId;
+                pushSkillTreeMessage(`Unlocked weapon: ${name}`, 'success');
+            }
+        }
+        return whole;
+    }
+    function allocateSkillPoint(skillId) {
+        var _a;
+        if (!progressionState) {
+            return false;
+        }
+        const node = SKILL_NODE_INDEX.get(skillId);
+        if (!node) {
+            return false;
+        }
+        const current = (_a = progressionState.skillAllocations[skillId]) !== null && _a !== void 0 ? _a : 0;
+        if (current >= node.maxRank || progressionState.statPoints <= 0) {
+            return false;
+        }
+        progressionState.skillAllocations[skillId] = current + 1;
+        progressionState.statPoints -= 1;
+        persistProgressionState();
+        recalcProgressionEffects();
+        if (typeof renderSkillTreeHook === 'function') {
+            try {
+                renderSkillTreeHook();
+            }
+            catch (error) {
+                console.error('skill tree render error', error);
+            }
+        }
+        if (typeof updateProgressionTelemetryHook === 'function') {
+            try {
+                updateProgressionTelemetryHook();
+            }
+            catch (error) {
+                console.error('progression telemetry update error', error);
+            }
+        }
+        const effectText = node.effectText ? node.effectText(progressionState.skillAllocations[skillId]) : '';
+        const message = effectText ? `${node.label} upgraded — ${effectText}` : `${node.label} upgraded`;
+        pushSkillTreeMessage(message, 'success');
+        return true;
+    }
+    function getProgressionState() {
+        return progressionState;
+    }
+    function setProgressionTelemetryUpdater(fn) {
+        updateProgressionTelemetryHook = typeof fn === 'function' ? fn : null;
+    }
+    function setSkillTreeRenderer(fn) {
+        renderSkillTreeHook = typeof fn === 'function' ? fn : null;
+    }
+    function setSkillTreeMessenger(fn) {
+        skillTreeMessageHook = typeof fn === 'function' ? fn : null;
+    }
+    progressionState = loadProgressionState();
+    const requiredExp = getExpRequirement(progressionState.level);
+    if (progressionState.exp >= requiredExp && progressionState.level < LEVEL_CAP) {
+        const surplus = Math.floor(progressionState.exp / requiredExp);
+        progressionState.level = Math.min(LEVEL_CAP, progressionState.level + surplus);
+        progressionState.statPoints += surplus * 2;
+        progressionState.exp = progressionState.exp % requiredExp;
+    }
+    else if (progressionState.level >= LEVEL_CAP) {
+        progressionState.level = LEVEL_CAP;
+        progressionState.exp = Math.min(getExpRequirement(LEVEL_CAP), progressionState.exp);
+    }
+    syncProgressionToCosmetics({ silent: true });
+    unlockWeaponsForLevel(progressionState.level, { announce: false });
+    recalcProgressionEffects();
+    const progressionSystem = {
+        addExperience: addProgressionExperience,
+        allocateSkillPoint,
+        getState: getProgressionState,
+        getEffects: () => ({ ...progressionEffects }),
+        syncCosmetics: syncProgressionToCosmetics
+    };
+    if (typeof window !== 'undefined') {
+        window.astrocatProgression = progressionSystem;
+        window.registerProgressionTelemetryUpdater = setProgressionTelemetryUpdater;
+        window.registerSkillTreeRenderer = setSkillTreeRenderer;
+        window.registerSkillTreeMessenger = setSkillTreeMessenger;
+    }
+    setSkillTreeRenderer(renderSkillTreeUI);
+    setSkillTreeMessenger(showSkillTreeMessage);
+    if (skillTreeListEl) {
+        skillTreeListEl.addEventListener('click', (event) => {
+            var _a;
+            const target = event.target instanceof HTMLElement ? event.target : null;
+            const button = target === null || target === void 0 ? void 0 : target.closest('[data-skill-upgrade]');
+            if (!(button instanceof HTMLButtonElement) || button.disabled) {
+                return;
+            }
+            const skillId = (_a = button.dataset.skillUpgrade) !== null && _a !== void 0 ? _a : '';
+            if (!skillId) {
+                return;
+            }
+            const upgraded = progressionSystem.allocateSkillPoint(skillId);
+            if (!upgraded) {
+                showSkillTreeMessage('Need more stat points. Fly missions to earn EXP.', 'warning');
+            }
+        });
+    }
+    setProgressionTelemetryUpdater(updateProgressionTelemetry);
+    renderSkillTreeUI();
+    updateProgressionTelemetry();
     const CUSTOM_LOADOUT_VERSION = 1;
     const CUSTOM_LOADOUT_SLOTS = [
         { slot: 'slotA', defaultName: 'Custom Loadout A' },
@@ -3999,7 +4677,7 @@ document.addEventListener('DOMContentLoaded', () => {
         var _a, _b;
         const base = fallback !== null && fallback !== void 0 ? fallback : createDefaultCustomLoadout(slotMeta, index);
         if (!entry || typeof entry !== 'object') {
-            return Object.assign({}, base);
+            return { ...base };
         }
         const slotId = (_a = slotMeta === null || slotMeta === void 0 ? void 0 : slotMeta.slot) !== null && _a !== void 0 ? _a : base.slot;
         const defaultName = (_b = slotMeta === null || slotMeta === void 0 ? void 0 : slotMeta.defaultName) !== null && _b !== void 0 ? _b : base.name;
@@ -4155,7 +4833,7 @@ document.addEventListener('DOMContentLoaded', () => {
             state.cosmetics.ownedWeapons = [...defaults.ownedWeapons];
         }
         if (!isPlainObject(state.cosmetics.equipped)) {
-            state.cosmetics.equipped = Object.assign({}, defaults.equipped);
+            state.cosmetics.equipped = { ...defaults.equipped };
         }
         return state.cosmetics;
     }
@@ -4961,6 +5639,10 @@ document.addEventListener('DOMContentLoaded', () => {
         }
         weaponCards = [];
         weaponSelectGrid.innerHTML = '';
+        const cosmetics = ensureCosmeticsState();
+        const ownedWeapons = new Set(Array.isArray(cosmetics === null || cosmetics === void 0 ? void 0 : cosmetics.ownedWeapons)
+            ? cosmetics.ownedWeapons.map((value) => String(value))
+            : []);
         for (const weapon of Object.values(weaponLoadouts)) {
             const button = document.createElement('button');
             button.type = 'button';
@@ -4997,17 +5679,33 @@ document.addEventListener('DOMContentLoaded', () => {
                 details.appendChild(list);
                 button.appendChild(details);
             }
-            button.addEventListener('click', () => {
-                pendingWeaponId = weapon.id;
-                updateWeaponSelectionState();
-            });
-            button.addEventListener('keydown', (event) => {
-                if (event.key === 'Enter' || event.key === ' ') {
-                    event.preventDefault();
+            const isUnlocked = ownedWeapons.has(weapon.id);
+            if (!isUnlocked) {
+                button.disabled = true;
+                button.tabIndex = -1;
+                button.setAttribute('aria-disabled', 'true');
+                button.classList.add('locked');
+                const unlockLevel = getWeaponUnlockRequirement(weapon.id);
+                const lockBadge = document.createElement('span');
+                lockBadge.className = 'weapon-lock-badge';
+                lockBadge.textContent = unlockLevel
+                    ? `Unlocks at Level ${unlockLevel}`
+                    : 'Unlock through special events';
+                button.appendChild(lockBadge);
+            }
+            else {
+                button.addEventListener('click', () => {
                     pendingWeaponId = weapon.id;
                     updateWeaponSelectionState();
-                }
-            });
+                });
+                button.addEventListener('keydown', (event) => {
+                    if (event.key === 'Enter' || event.key === ' ') {
+                        event.preventDefault();
+                        pendingWeaponId = weapon.id;
+                        updateWeaponSelectionState();
+                    }
+                });
+            }
             weaponSelectGrid.appendChild(button);
             weaponCards.push(button);
         }
@@ -5111,6 +5809,7 @@ document.addEventListener('DOMContentLoaded', () => {
         updateActiveLoadoutPrompt();
     }
     initializeLoadoutSelections();
+    progressionSystem.syncCosmetics({ silent: true });
     renderPilotSelectGrid();
     renderWeaponSelectGrid();
     renderCustomLoadoutCollections();
@@ -5273,9 +5972,9 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     }
     async function fetchWithTimeout(resource, options = {}) {
-        const _a = options !== null && options !== void 0 ? options : {}, { timeout = API_CONFIG.timeoutMs, signal } = _a, rest = __rest(_a, ["timeout", "signal"]);
+        const { timeout = API_CONFIG.timeoutMs, signal, ...rest } = options !== null && options !== void 0 ? options : {};
         if (typeof AbortController === 'undefined' || !timeout || timeout <= 0) {
-            return fetch(resource, Object.assign({ signal }, rest));
+            return fetch(resource, { signal, ...rest });
         }
         const controller = new AbortController();
         const timers = setTimeout(() => {
@@ -5293,7 +5992,7 @@ document.addEventListener('DOMContentLoaded', () => {
         }
         try {
             const combinedSignal = controller.signal;
-            return await fetch(resource, Object.assign(Object.assign({}, rest), { signal: combinedSignal }));
+            return await fetch(resource, { ...rest, signal: combinedSignal });
         }
         finally {
             clearTimeout(timers);
@@ -5703,7 +6402,7 @@ document.addEventListener('DOMContentLoaded', () => {
         reducedEffects: systemPrefersReducedEffects(),
         difficulty: DEFAULT_DIFFICULTY_ID
     };
-    let settingsState = Object.assign({}, DEFAULT_SETTINGS);
+    let settingsState = { ...DEFAULT_SETTINGS };
     function sanitizeVolume(value, fallback = DEFAULT_SETTINGS.masterVolume) {
         const numeric = Number(value);
         if (!Number.isFinite(numeric)) {
@@ -5713,7 +6412,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     function coerceSettings(partial, base = settingsState !== null && settingsState !== void 0 ? settingsState : DEFAULT_SETTINGS) {
         var _a, _b;
-        const source = Object.assign({}, base);
+        const source = { ...base };
         if (partial && typeof partial === 'object') {
             if (Object.prototype.hasOwnProperty.call(partial, 'masterVolume')) {
                 source.masterVolume = partial.masterVolume;
@@ -5742,11 +6441,11 @@ document.addEventListener('DOMContentLoaded', () => {
     function loadSettingsPreferences() {
         hasStoredSettings = false;
         if (!storageAvailable) {
-            return Object.assign({}, DEFAULT_SETTINGS);
+            return { ...DEFAULT_SETTINGS };
         }
         const raw = readStorage(STORAGE_KEYS.settings);
         if (!raw) {
-            return Object.assign({}, DEFAULT_SETTINGS);
+            return { ...DEFAULT_SETTINGS };
         }
         try {
             const parsed = JSON.parse(raw);
@@ -5756,7 +6455,7 @@ document.addEventListener('DOMContentLoaded', () => {
         }
         catch (error) {
             hasStoredSettings = false;
-            return Object.assign({}, DEFAULT_SETTINGS);
+            return { ...DEFAULT_SETTINGS };
         }
     }
     function persistSettingsPreferences() {
@@ -5983,14 +6682,20 @@ document.addEventListener('DOMContentLoaded', () => {
         if (reward.type === 'bundle') {
             if (Array.isArray(reward.items)) {
                 for (const item of reward.items) {
-                    registerCosmeticRewardSource(map, item, Object.assign(Object.assign({}, source), { bundle: (_b = (_a = reward.label) !== null && _a !== void 0 ? _a : source === null || source === void 0 ? void 0 : source.title) !== null && _b !== void 0 ? _b : 'Bundle' }));
+                    registerCosmeticRewardSource(map, item, {
+                        ...source,
+                        bundle: (_b = (_a = reward.label) !== null && _a !== void 0 ? _a : source === null || source === void 0 ? void 0 : source.title) !== null && _b !== void 0 ? _b : 'Bundle'
+                    });
                 }
             }
             return;
         }
         if (reward.type === 'cosmetic' && reward.id) {
             const list = (_c = map.get(reward.id)) !== null && _c !== void 0 ? _c : [];
-            list.push(Object.assign(Object.assign({}, source), { reward }));
+            list.push({
+                ...source,
+                reward
+            });
             map.set(reward.id, list);
         }
     }
@@ -6064,7 +6769,7 @@ document.addEventListener('DOMContentLoaded', () => {
         return {
             ownedSkins: ['default'],
             ownedTrails: ['rainbow'],
-            ownedWeapons: ['pulse', 'scatter', 'lance'],
+            ownedWeapons: ['pulse'],
             equipped: { skin: 'default', trail: 'rainbow', weapon: 'pulse' }
         };
     }
@@ -6095,7 +6800,7 @@ document.addEventListener('DOMContentLoaded', () => {
         }
         const normalized = { metric, target, mode };
         if (goal.filter && typeof goal.filter === 'object') {
-            normalized.filter = Object.assign({}, goal.filter);
+            normalized.filter = { ...goal.filter };
         }
         return normalized;
     }
@@ -6134,10 +6839,10 @@ document.addEventListener('DOMContentLoaded', () => {
                 ? raw.history
                     .filter((entry) => isPlainObject(entry))
                     .slice(-24)
-                    .map((entry) => (Object.assign({}, entry)))
+                    .map((entry) => ({ ...entry }))
                 : [],
-            cosmetics: isPlainObject(raw.cosmetics) ? Object.assign({}, raw.cosmetics) : createDefaultCosmeticsState(),
-            milestones: isPlainObject(raw.milestones) ? Object.assign({}, raw.milestones) : { streak: { achieved: [] } }
+            cosmetics: isPlainObject(raw.cosmetics) ? { ...raw.cosmetics } : createDefaultCosmeticsState(),
+            milestones: isPlainObject(raw.milestones) ? { ...raw.milestones } : { streak: { achieved: [] } }
         };
         const slots = isPlainObject(raw.slots) ? raw.slots : {};
         for (const [slotKey, entry] of Object.entries(slots)) {
@@ -6175,7 +6880,7 @@ document.addEventListener('DOMContentLoaded', () => {
             }
         }
         if (!isPlainObject(state.cosmetics.equipped)) {
-            state.cosmetics.equipped = Object.assign({}, defaultCosmetics.equipped);
+            state.cosmetics.equipped = { ...defaultCosmetics.equipped };
         }
         else {
             const equippedSkin = typeof state.cosmetics.equipped.skin === 'string'
@@ -6395,7 +7100,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 }
                 for (const definition of list) {
                     if (definition && typeof definition === 'object' && typeof definition.id === 'string') {
-                        definitionIndex.set(definition.id, Object.assign(Object.assign({}, definition), { slot: slotKey }));
+                        definitionIndex.set(definition.id, { ...definition, slot: slotKey });
                     }
                 }
             }
@@ -6517,17 +7222,17 @@ document.addEventListener('DOMContentLoaded', () => {
                 version: CHALLENGE_STATE_VERSION,
                 slots: {},
                 history: Array.isArray(state.history)
-                    ? state.history.slice(-24).map((entry) => (Object.assign({}, entry)))
+                    ? state.history.slice(-24).map((entry) => ({ ...entry }))
                     : [],
                 cosmetics: {
                     ownedSkins: [...state.cosmetics.ownedSkins],
                     ownedTrails: [...state.cosmetics.ownedTrails],
                     ownedWeapons: [...state.cosmetics.ownedWeapons],
-                    equipped: Object.assign({}, state.cosmetics.equipped)
+                    equipped: { ...state.cosmetics.equipped }
                 }
             };
             for (const [slotKey, entry] of Object.entries(state.slots)) {
-                snapshot.slots[slotKey] = Object.assign(Object.assign({}, entry), { goal: Object.assign({}, entry.goal), slot: slotKey });
+                snapshot.slots[slotKey] = { ...entry, goal: { ...entry.goal }, slot: slotKey };
             }
             snapshot.milestones = {
                 streak: Array.isArray((_b = (_a = state.milestones) === null || _a === void 0 ? void 0 : _a.streak) === null || _b === void 0 ? void 0 : _b.achieved)
@@ -6619,7 +7324,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 const current = state.slots[slotKey];
                 if (!current || current.challengeId !== definition.id || current.rotation !== rotationId) {
                     if (current) {
-                        state.history.push(Object.assign(Object.assign({}, current), { archivedAt: Date.now(), slot: slotKey }));
+                        state.history.push({ ...current, archivedAt: Date.now(), slot: slotKey });
                         state.history = state.history.slice(-24);
                     }
                     state.slots[slotKey] = {
@@ -6675,7 +7380,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     try {
                         onChallengeCompleted(completion.definition, {
                             slot: completion.slot,
-                            progress: Object.assign({}, completion.entry),
+                            progress: { ...completion.entry },
                             reward: (_b = (_a = completion.definition) === null || _a === void 0 ? void 0 : _a.reward) !== null && _b !== void 0 ? _b : null
                         });
                     }
@@ -6752,7 +7457,7 @@ document.addEventListener('DOMContentLoaded', () => {
                         id: entry.challengeId,
                         slot: slotKey
                     };
-                    completions.push({ slot: slotKey, entry: Object.assign({}, entry), definition });
+                    completions.push({ slot: slotKey, entry: { ...entry }, definition });
                 }
             }
             if (mutated) {
@@ -7015,16 +7720,28 @@ document.addEventListener('DOMContentLoaded', () => {
             const community = COMMUNITY_GOALS.map((goal) => {
                 const entry = ensureCommunityEntry(state, goal.id);
                 const percent = goal.target > 0 ? Math.min(100, Math.round((entry.progress / goal.target) * 100)) : 0;
-                return Object.assign(Object.assign({}, goal), { progress: entry.progress, contributions: entry.contributions, completedAt: entry.completedAt, percent });
+                return {
+                    ...goal,
+                    progress: entry.progress,
+                    contributions: entry.contributions,
+                    completedAt: entry.completedAt,
+                    percent
+                };
             });
             return {
                 achievements: ACHIEVEMENT_DEFINITIONS.map((definition) => {
                     var _a, _b;
-                    return (Object.assign(Object.assign({}, definition), { unlockedAt: (_b = (_a = state.achievements[definition.id]) === null || _a === void 0 ? void 0 : _a.unlockedAt) !== null && _b !== void 0 ? _b : null }));
+                    return ({
+                        ...definition,
+                        unlockedAt: (_b = (_a = state.achievements[definition.id]) === null || _a === void 0 ? void 0 : _a.unlockedAt) !== null && _b !== void 0 ? _b : null
+                    });
                 }),
                 communityGoals: community,
                 streak: {
-                    milestones: STREAK_MILESTONES.map((milestone) => (Object.assign(Object.assign({}, milestone), { earned: state.streak.milestonesEarned.includes(milestone.id) })))
+                    milestones: STREAK_MILESTONES.map((milestone) => ({
+                        ...milestone,
+                        earned: state.streak.milestonesEarned.includes(milestone.id)
+                    }))
                 }
             };
         }
@@ -7798,7 +8515,11 @@ document.addEventListener('DOMContentLoaded', () => {
     function applyLeaderboardSnapshot(snapshot, { source = 'remote', persist = true } = {}) {
         var _a, _b, _c;
         const sanitized = sanitizeLeaderboardSnapshot(snapshot);
-        leaderboardState.scopes = Object.assign(Object.assign({}, leaderboardState.scopes), { global: (_a = sanitized.global) !== null && _a !== void 0 ? _a : [], weekly: (_b = sanitized.weekly) !== null && _b !== void 0 ? _b : [] });
+        leaderboardState.scopes = {
+            ...leaderboardState.scopes,
+            global: (_a = sanitized.global) !== null && _a !== void 0 ? _a : [],
+            weekly: (_b = sanitized.weekly) !== null && _b !== void 0 ? _b : []
+        };
         leaderboardState.fetchedAt = (_c = sanitized.fetchedAt) !== null && _c !== void 0 ? _c : Date.now();
         leaderboardState.source = source;
         leaderboardState.error = null;
@@ -8647,7 +9368,7 @@ document.addEventListener('DOMContentLoaded', () => {
         ? baseGameConfig.score
         : {};
     if (!config.score || !isPlainObject(config.score)) {
-        config.score = Object.assign({}, fallbackScoreConfig);
+        config.score = { ...fallbackScoreConfig };
     }
     config.score.collect = baseCollectScore;
     const collectibleTiers = [
@@ -9586,7 +10307,7 @@ document.addEventListener('DOMContentLoaded', () => {
             key: 'villain1',
             name: 'Void Raider',
             imageSrc: 'assets/villain1.png',
-            size: Object.assign({}, ((_31 = villainSizeProfiles.small) !== null && _31 !== void 0 ? _31 : { min: 59, max: 77 })),
+            size: { ...((_31 = villainSizeProfiles.small) !== null && _31 !== void 0 ? _31 : { min: 59, max: 77 }) },
             speedOffset: { min: 14, max: 34 },
             rotation: { min: -1.8, max: 1.8 },
             baseHealth: 1,
@@ -9597,7 +10318,7 @@ document.addEventListener('DOMContentLoaded', () => {
             key: 'villain2',
             name: 'Nebula Marauder',
             imageSrc: 'assets/villain2.png',
-            size: Object.assign({}, ((_32 = villainSizeProfiles.medium) !== null && _32 !== void 0 ? _32 : { min: 93, max: 126 })),
+            size: { ...((_32 = villainSizeProfiles.medium) !== null && _32 !== void 0 ? _32 : { min: 93, max: 126 }) },
             speedOffset: { min: 8, max: 30 },
             rotation: { min: -1.4, max: 1.4 },
             baseHealth: 2.3,
@@ -9608,7 +10329,7 @@ document.addEventListener('DOMContentLoaded', () => {
             key: 'villain3',
             name: 'Abyss Overlord',
             imageSrc: 'assets/villain3.png',
-            size: Object.assign({}, ((_33 = villainSizeProfiles.large) !== null && _33 !== void 0 ? _33 : { min: 135, max: 183 })),
+            size: { ...((_33 = villainSizeProfiles.large) !== null && _33 !== void 0 ? _33 : { min: 135, max: 183 }) },
             speedOffset: { min: -2, max: 32 },
             rotation: { min: -1, max: 1 },
             baseHealth: 3.4,
@@ -11662,8 +12383,10 @@ document.addEventListener('DOMContentLoaded', () => {
         const loadout = getActiveWeaponLoadout();
         const cooldownMultiplier = (_a = loadout === null || loadout === void 0 ? void 0 : loadout.cooldownMultiplier) !== null && _a !== void 0 ? _a : 1;
         const cooldownOffset = (_b = loadout === null || loadout === void 0 ? void 0 : loadout.cooldownOffset) !== null && _b !== void 0 ? _b : 0;
-        const cooldown = Math.max(60, config.projectileCooldown * cooldownMultiplier + cooldownOffset);
-        if ((keys.has('Space') || virtualInput.firing || gamepadInput.firing) && state.timeSinceLastShot >= cooldown) {
+        const baseCooldown = config.projectileCooldown * cooldownMultiplier + cooldownOffset;
+        const adjustedCooldown = Math.max(40, baseCooldown * progressionEffects.cooldownMultiplier);
+        if ((keys.has('Space') || virtualInput.firing || gamepadInput.firing) &&
+            state.timeSinceLastShot >= adjustedCooldown) {
             spawnProjectiles();
             state.timeSinceLastShot = 0;
         }
@@ -11695,19 +12418,21 @@ document.addEventListener('DOMContentLoaded', () => {
             const applyLoadoutSpeed = overrides.applyLoadoutSpeed !== false;
             const speedMultiplier = ((_c = (_b = overrides.speedMultiplier) !== null && _b !== void 0 ? _b : archetype === null || archetype === void 0 ? void 0 : archetype.speedMultiplier) !== null && _c !== void 0 ? _c : 1) *
                 (applyLoadoutSpeed ? loadoutSpeedMultiplier : 1);
-            const speed = config.projectileSpeed * speedMultiplier;
+            const speed = config.projectileSpeed * speedMultiplier * progressionEffects.projectileSpeedMultiplier;
             const vx = Math.cos(angle) * speed;
             const vy = Math.sin(angle) * speed;
+            const baseDamage = (_e = (_d = overrides.damage) !== null && _d !== void 0 ? _d : archetype === null || archetype === void 0 ? void 0 : archetype.damage) !== null && _e !== void 0 ? _e : 1;
             const projectile = {
-                x: originX + ((_d = overrides.offsetX) !== null && _d !== void 0 ? _d : 0),
-                y: originY + ((_e = overrides.offsetY) !== null && _e !== void 0 ? _e : 0),
-                width: (_g = (_f = overrides.width) !== null && _f !== void 0 ? _f : archetype === null || archetype === void 0 ? void 0 : archetype.width) !== null && _g !== void 0 ? _g : 24,
-                height: (_j = (_h = overrides.height) !== null && _h !== void 0 ? _h : archetype === null || archetype === void 0 ? void 0 : archetype.height) !== null && _j !== void 0 ? _j : 12,
+                x: originX + ((_f = overrides.offsetX) !== null && _f !== void 0 ? _f : 0),
+                y: originY + ((_g = overrides.offsetY) !== null && _g !== void 0 ? _g : 0),
+                width: (_j = (_h = overrides.width) !== null && _h !== void 0 ? _h : archetype === null || archetype === void 0 ? void 0 : archetype.width) !== null && _j !== void 0 ? _j : 24,
+                height: (_l = (_k = overrides.height) !== null && _k !== void 0 ? _k : archetype === null || archetype === void 0 ? void 0 : archetype.height) !== null && _l !== void 0 ? _l : 12,
                 vx,
                 vy,
-                life: (_l = (_k = overrides.life) !== null && _k !== void 0 ? _k : archetype === null || archetype === void 0 ? void 0 : archetype.life) !== null && _l !== void 0 ? _l : 2000,
+                life: (_o = (_m = overrides.life) !== null && _m !== void 0 ? _m : archetype === null || archetype === void 0 ? void 0 : archetype.life) !== null && _o !== void 0 ? _o : 2000,
                 type,
-                damage: (_o = (_m = overrides.damage) !== null && _m !== void 0 ? _m : archetype === null || archetype === void 0 ? void 0 : archetype.damage) !== null && _o !== void 0 ? _o : 1,
+                damage: baseDamage,
+                baseDamage,
                 gradient: (_q = (_p = overrides.gradient) !== null && _p !== void 0 ? _p : archetype === null || archetype === void 0 ? void 0 : archetype.gradient) !== null && _q !== void 0 ? _q : null,
                 glow: (_s = (_r = overrides.glow) !== null && _r !== void 0 ? _r : archetype === null || archetype === void 0 ? void 0 : archetype.glow) !== null && _s !== void 0 ? _s : null,
                 shape: (_u = (_t = overrides.shape) !== null && _t !== void 0 ? _t : archetype === null || archetype === void 0 ? void 0 : archetype.shape) !== null && _u !== void 0 ? _u : null,
@@ -11965,6 +12690,7 @@ document.addEventListener('DOMContentLoaded', () => {
         doubleTeamState.linkPulse = force ? 0 : Math.max(doubleTeamState.linkPulse, 0.5);
     }
     function updatePlayer(delta) {
+        var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m;
         const deltaSeconds = delta / 1000;
         const keyboardX = (keys.has('ArrowRight') || keys.has('KeyD') ? 1 : 0) - (keys.has('ArrowLeft') || keys.has('KeyA') ? 1 : 0);
         const keyboardY = (keys.has('ArrowDown') || keys.has('KeyS') ? 1 : 0) - (keys.has('ArrowUp') || keys.has('KeyW') ? 1 : 0);
@@ -12006,23 +12732,24 @@ document.addEventListener('DOMContentLoaded', () => {
         const baseInputX = clamp(keyboardX + virtualX + gamepadInput.moveX + motionX, -1, 1);
         const baseInputY = clamp(keyboardY + virtualY + gamepadInput.moveY + motionY, -1, 1);
         const environmentPhysics = getEnvironmentPhysics();
-        const inputScale = environmentPhysics.inputResponsiveness !== undefined ? environmentPhysics.inputResponsiveness : 1;
+        const inputScale = (_a = environmentPhysics.inputResponsiveness) !== null && _a !== void 0 ? _a : 1;
         const inputX = baseInputX * inputScale;
         const inputY = baseInputY * inputScale;
-        const accel = config.player.acceleration * (environmentPhysics.accelerationMultiplier !== undefined ? environmentPhysics.accelerationMultiplier : 1);
-        const baseDrag = config.player.drag * (environmentPhysics.dragMultiplier !== undefined ? environmentPhysics.dragMultiplier : 1);
-        const dashConfig = config.player.dash || { boostSpeed: config.player.maxSpeed, dragMultiplier: 1 };
+        const accel = config.player.acceleration * ((_b = environmentPhysics.accelerationMultiplier) !== null && _b !== void 0 ? _b : 1);
+        const baseDrag = config.player.drag * ((_c = environmentPhysics.dragMultiplier) !== null && _c !== void 0 ? _c : 1);
+        const dashConfig = (_d = config.player.dash) !== null && _d !== void 0 ? _d : { boostSpeed: config.player.maxSpeed, dragMultiplier: 1 };
         const isDashing = state.dashTimer > 0;
-        const dashDragMultiplier = dashConfig.dragMultiplier !== undefined ? dashConfig.dragMultiplier : 1;
+        const dashDragMultiplier = (_e = dashConfig.dragMultiplier) !== null && _e !== void 0 ? _e : 1;
         const horizontalDrag = isDashing ? baseDrag * dashDragMultiplier : baseDrag;
-        const verticalDrag = horizontalDrag * (environmentPhysics.verticalDragMultiplier !== undefined ? environmentPhysics.verticalDragMultiplier : 1);
-        const baseMaxSpeed = config.player.maxSpeed * (environmentPhysics.maxSpeedMultiplier !== undefined ? environmentPhysics.maxSpeedMultiplier : 1);
-        const dashSpeed = (dashConfig.boostSpeed !== undefined ? dashConfig.boostSpeed : config.player.maxSpeed) * (environmentPhysics.dashSpeedMultiplier !== undefined ? environmentPhysics.dashSpeedMultiplier : 1);
+        const verticalDrag = horizontalDrag * ((_f = environmentPhysics.verticalDragMultiplier) !== null && _f !== void 0 ? _f : 1);
+        const baseMaxSpeed = config.player.maxSpeed * ((_g = environmentPhysics.maxSpeedMultiplier) !== null && _g !== void 0 ? _g : 1);
+        const dashSpeed = ((_h = dashConfig.boostSpeed) !== null && _h !== void 0 ? _h : config.player.maxSpeed) * ((_j = environmentPhysics.dashSpeedMultiplier) !== null && _j !== void 0 ? _j : 1);
         const maxSpeed = isDashing ? dashSpeed : baseMaxSpeed;
-        const buoyancy = environmentPhysics.buoyancy !== undefined ? environmentPhysics.buoyancy : 0;
-        const swayStrength = environmentPhysics.swayStrength !== undefined ? environmentPhysics.swayStrength : 0;
-        const swayFrequency = environmentPhysics.swayFrequency !== undefined ? environmentPhysics.swayFrequency : 0.0012;
+        const buoyancy = (_k = environmentPhysics.buoyancy) !== null && _k !== void 0 ? _k : 0;
+        const swayStrength = (_l = environmentPhysics.swayStrength) !== null && _l !== void 0 ? _l : 0;
+        const swayFrequency = (_m = environmentPhysics.swayFrequency) !== null && _m !== void 0 ? _m : 0.0012;
         const moveEntity = (entity) => {
+            var _a, _b;
             if (!entity) {
                 return;
             }
@@ -12037,8 +12764,8 @@ document.addEventListener('DOMContentLoaded', () => {
             entity.x += entity.vx * deltaSeconds;
             entity.y += entity.vy * deltaSeconds;
             if (swayStrength !== 0) {
-                const elapsed = state && typeof state.elapsedTime === 'number' ? state.elapsedTime : 0;
-                const swayPhase = elapsed * swayFrequency + (environmentState.swaySeed || 0) + entity.y * 0.015;
+                const elapsed = (_a = state === null || state === void 0 ? void 0 : state.elapsedTime) !== null && _a !== void 0 ? _a : 0;
+                const swayPhase = elapsed * swayFrequency + ((_b = environmentState.swaySeed) !== null && _b !== void 0 ? _b : 0) + entity.y * 0.015;
                 entity.x += Math.sin(swayPhase) * swayStrength * deltaSeconds;
             }
             entity.x = clamp(entity.x, 0, viewport.width - entity.width);
@@ -12246,7 +12973,7 @@ document.addEventListener('DOMContentLoaded', () => {
         return (_a = closest === null || closest === void 0 ? void 0 : closest.obstacle) !== null && _a !== void 0 ? _a : null;
     }
     function updateProjectiles(delta) {
-        var _a, _b, _c, _d, _e, _f, _g;
+        var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q;
         const deltaSeconds = delta / 1000;
         for (let i = projectiles.length - 1; i >= 0; i--) {
             const projectile = projectiles[i];
@@ -12295,6 +13022,27 @@ document.addEventListener('DOMContentLoaded', () => {
                         });
                     }
                 }
+            }
+            else if (projectile.type === 'cyclone') {
+                projectile.waveTime = ((_h = projectile.waveTime) !== null && _h !== void 0 ? _h : 0) + delta;
+                const phase = (_j = projectile.wavePhase) !== null && _j !== void 0 ? _j : 0;
+                const frequency = (_k = projectile.waveFrequency) !== null && _k !== void 0 ? _k : 7.8;
+                const amplitude = (_l = projectile.waveAmplitude) !== null && _l !== void 0 ? _l : 16;
+                const drift = (_m = projectile.waveDrift) !== null && _m !== void 0 ? _m : 26;
+                const waveSeconds = projectile.waveTime / 1000;
+                projectile.curve = Math.sin(waveSeconds * frequency + phase) * amplitude;
+                projectile.y += Math.cos(waveSeconds * (frequency * 0.6) + phase * 0.4) * drift * deltaSeconds * 0.12;
+            }
+            else if (projectile.type === 'nebula') {
+                projectile.pulseTime = ((_o = projectile.pulseTime) !== null && _o !== void 0 ? _o : 0) + delta;
+                const pulseSeconds = projectile.pulseTime / 260;
+                const pulse = Math.sin(pulseSeconds) * 0.3 + 1.05;
+                projectile.pulseScale = pulse;
+                projectile.vy += Math.sin(pulseSeconds * 1.4) * deltaSeconds * 18;
+            }
+            else if (projectile.type === 'quasar') {
+                projectile.spin = ((_p = projectile.spin) !== null && _p !== void 0 ? _p : 0) + delta * 0.0042;
+                projectile.pulse = ((_q = projectile.pulse) !== null && _q !== void 0 ? _q : 0) + delta * 0.0035;
             }
             projectile.x += projectile.vx * deltaSeconds;
             projectile.y += projectile.vy * deltaSeconds;
@@ -13443,21 +14191,18 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     }
     function updateStars(delta) {
+        var _a, _b, _c, _d;
         const scaledDelta = getScaledDelta(delta);
         const deltaSeconds = scaledDelta / 1000;
         if (isUnderwaterEnvironment()) {
-            const starConfig = config && typeof config === 'object' ? config.star : undefined;
-            const starBase = starConfig && typeof starConfig.baseSpeed === 'number' ? starConfig.baseSpeed : NaN;
-            const baseSpeed = Number.isFinite(starBase) ? starBase : 80;
-            const elapsed = (state && typeof state === 'object' && typeof state.elapsedTime === 'number')
-                ? state.elapsedTime
-                : 0;
+            const baseSpeed = Number.isFinite((_a = config === null || config === void 0 ? void 0 : config.star) === null || _a === void 0 ? void 0 : _a.baseSpeed) ? config.star.baseSpeed : 80;
+            const elapsed = (_b = state === null || state === void 0 ? void 0 : state.elapsedTime) !== null && _b !== void 0 ? _b : 0;
             const upwardFactor = 0.22 + state.gameSpeed / 900;
             for (let i = stars.length - 1; i >= 0; i--) {
                 const star = stars[i];
-                const rippleOffset = star.rippleOffset || 0;
+                const rippleOffset = (_c = star.rippleOffset) !== null && _c !== void 0 ? _c : 0;
                 star.y -= star.speed * deltaSeconds * upwardFactor;
-                const drift = star.drift || 0;
+                const drift = (_d = star.drift) !== null && _d !== void 0 ? _d : 0;
                 if (drift !== 0) {
                     const swayPhase = elapsed * 0.0012 + rippleOffset;
                     star.x += Math.sin(swayPhase) * drift * deltaSeconds;
@@ -13544,15 +14289,14 @@ document.addEventListener('DOMContentLoaded', () => {
         if (!projectile) {
             return 1;
         }
-        if (Number.isFinite(projectile.damage)) {
-            return Math.max(1, projectile.damage);
-        }
-        switch (projectile.type) {
-            case 'missile':
-                return 2;
-            default:
-                return 1;
-        }
+        const baseDamage = Number.isFinite(projectile.baseDamage)
+            ? projectile.baseDamage
+            : Number.isFinite(projectile.damage)
+                ? projectile.damage
+                : projectile.type === 'missile'
+                    ? 2
+                    : 1;
+        return Math.max(1, Math.round(baseDamage * progressionEffects.damageMultiplier));
     }
     function updateProjectilesCollisions() {
         var _a, _b;
@@ -14078,17 +14822,19 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     }
     function awardDodge() {
-        state.score += config.score.dodge;
+        const dodgePoints = Math.max(1, Math.floor(config.score.dodge * progressionEffects.scoreMultiplier));
+        state.score += dodgePoints;
         state.comboTimer = Math.max(0, state.comboTimer - 400);
         const center = getPlayerCenter();
         spawnFloatingText({
-            text: `+${config.score.dodge} Dodge`,
+            text: `+${dodgePoints} Dodge`,
             x: center.x + player.width * 0.5,
             y: center.y,
             color: '#fde68a',
             life: 900,
             variant: 'dodge'
         });
+        progressionSystem.addExperience(dodgePoints, { source: 'dodge' });
     }
     function getVillainEscapePenalty(obstacle) {
         var _a, _b, _c, _d;
@@ -14112,7 +14858,7 @@ document.addEventListener('DOMContentLoaded', () => {
             });
             triggerScreenShake(8, 240);
         }
-        state.comboTimer = config.comboDecayWindow;
+        state.comboTimer = getComboDecayWindow();
         resetStreak();
         const sparkCenter = getPlayerCenter();
         createHitSpark({
@@ -14149,8 +14895,8 @@ document.addEventListener('DOMContentLoaded', () => {
         mascotAnnouncer.cheerForCombo(state.streak);
         const comboMultiplier = 1 + state.streak * config.comboMultiplierStep;
         const surgeMultiplier = getScoreSurgeMultiplier();
-        const totalMultiplier = comboMultiplier * surgeMultiplier;
-        const finalPoints = Math.floor(basePoints * totalMultiplier);
+        const totalMultiplier = comboMultiplier * surgeMultiplier * progressionEffects.scoreMultiplier;
+        const finalPoints = Math.max(0, Math.floor(basePoints * totalMultiplier));
         state.score += finalPoints;
         storyManager.recordEvent('score', { totalScore: state.score, deltaScore: finalPoints });
         if (activeChallengeManager) {
@@ -14159,6 +14905,7 @@ document.addEventListener('DOMContentLoaded', () => {
         if (metaProgressManager) {
             metaProgressManager.recordScore(finalPoints, { totalScore: state.score });
         }
+        progressionSystem.addExperience(finalPoints, { source: 'score' });
         const originX = (_a = source.x) !== null && _a !== void 0 ? _a : player.x + player.width * 0.5;
         const originY = (_b = source.y) !== null && _b !== void 0 ? _b : player.y;
         const text = `+${finalPoints.toLocaleString()}${totalMultiplier > 1.01 ? ` x${totalMultiplier.toFixed(2)}` : ''}`;
@@ -14174,6 +14921,10 @@ document.addEventListener('DOMContentLoaded', () => {
             triggerScreenShake(Math.min(16, 6 + finalPoints / 400), 280);
         }
     }
+    function getComboDecayWindow() {
+        const baseWindow = getComboDecayWindow();
+        return Math.max(1000, Math.round(baseWindow * progressionEffects.comboWindowMultiplier));
+    }
     function resetStreak() {
         const hadStreak = state.streak > 0;
         state.streak = 0;
@@ -14186,7 +14937,7 @@ document.addEventListener('DOMContentLoaded', () => {
         if (!pendingSubmission) {
             return null;
         }
-        const summary = Object.assign({}, pendingSubmission);
+        const summary = { ...pendingSubmission };
         summary.recorded = Boolean(recorded);
         summary.reason = reason !== null && reason !== void 0 ? reason : null;
         summary.placement = placement !== null && placement !== void 0 ? placement : null;
@@ -14408,7 +15159,7 @@ document.addEventListener('DOMContentLoaded', () => {
         if (!pendingSubmission) {
             return;
         }
-        const submission = Object.assign({}, pendingSubmission);
+        const submission = { ...pendingSubmission };
         submission.player = commitPlayerNameInput();
         pendingSubmission.player = submission.player;
         setOverlaySubmittingState(true);
@@ -14501,10 +15252,11 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     function updateCombo(delta) {
         state.comboTimer += delta;
-        if (state.comboTimer >= config.comboDecayWindow && state.streak > 0) {
+        const comboWindow = getComboDecayWindow();
+        if (state.comboTimer >= comboWindow && state.streak > 0) {
             resetStreak();
         }
-        const ratio = clamp(1 - state.comboTimer / config.comboDecayWindow, 0, 1);
+        const ratio = clamp(1 - state.comboTimer / comboWindow, 0, 1);
         const percentage = Math.round(ratio * 100);
         if (percentage !== lastComboPercent) {
             if (comboFillEl) {
@@ -14564,46 +15316,12 @@ document.addEventListener('DOMContentLoaded', () => {
         }
         const activeBoosts = powerUpTypes
             .filter((type) => isPowerUpActive(type))
-            .map((type) => {
-            const label = powerUpLabels[type];
-            const remainingSeconds = Math.max(0, state.powerUpTimers[type] / 1000);
-            return {
-                label,
-                remainingSeconds,
-                formatted: `${label} ${remainingSeconds.toFixed(1)}s`
-            };
-        });
-        const powerUpText = activeBoosts.length
-            ? activeBoosts.map((entry) => entry.formatted).join(' | ')
-            : 'None';
+            .map((type) => `${powerUpLabels[type]} ${(state.powerUpTimers[type] / 1000).toFixed(1)}s`);
+        const powerUpText = activeBoosts.length ? activeBoosts.join(' | ') : 'None';
         if (powerUpText !== hudCache.powerUps) {
             hudCache.powerUps = powerUpText;
             if (powerUpsEl) {
-                if (!activeBoosts.length) {
-                    powerUpsEl.textContent = 'None';
-                    powerUpsEl.classList.add('power-up-list--empty');
-                    powerUpsEl.setAttribute('aria-label', 'No boosts active');
-                    powerUpsEl.removeAttribute('data-count');
-                }
-                else {
-                    powerUpsEl.classList.remove('power-up-list--empty');
-                    powerUpsEl.textContent = '';
-                    powerUpsEl.setAttribute('aria-label', 'Active boosts');
-                    powerUpsEl.setAttribute('data-count', String(activeBoosts.length));
-                    for (const boost of activeBoosts) {
-                        const pill = document.createElement('span');
-                        pill.className = 'power-up-pill';
-                        pill.setAttribute('role', 'listitem');
-                        const labelEl = document.createElement('span');
-                        labelEl.className = 'power-up-pill__label';
-                        labelEl.textContent = boost.label;
-                        const timerEl = document.createElement('span');
-                        timerEl.className = 'power-up-pill__timer';
-                        timerEl.textContent = `${boost.remainingSeconds.toFixed(1)}s`;
-                        pill.append(labelEl, timerEl);
-                        powerUpsEl.appendChild(pill);
-                    }
-                }
+                powerUpsEl.textContent = powerUpText;
             }
         }
     }
@@ -14632,28 +15350,29 @@ document.addEventListener('DOMContentLoaded', () => {
         ctx.fillRect(0, 0, viewport.width, viewport.height);
     }
     function drawStars(time) {
+        var _a, _b;
         ctx.save();
         if (isUnderwaterEnvironment()) {
             ctx.globalCompositeOperation = 'screen';
             for (const star of stars) {
-                const rippleOffset = star.rippleOffset || 0;
+                const rippleOffset = (_a = star.rippleOffset) !== null && _a !== void 0 ? _a : 0;
                 const twinkle = (Math.sin(time * 0.002 + star.twinkleOffset) + 1) * 0.5;
-                const radius = Math.max(1.4, (star.size || 1.2) * (1.8 + twinkle * 0.5));
+                const radius = Math.max(1.4, ((_b = star.size) !== null && _b !== void 0 ? _b : 1.2) * (1.8 + twinkle * 0.5));
                 const wobble = Math.sin(time * 0.003 + rippleOffset) * 2.4;
                 const bubbleX = star.x + Math.sin(time * 0.0011 + rippleOffset) * 2.2;
                 const bubbleY = star.y + wobble;
                 const innerAlpha = 0.32 + twinkle * 0.22;
                 const shellAlpha = 0.24 + twinkle * 0.18;
                 const gradient = ctx.createRadialGradient(bubbleX, bubbleY, radius * 0.28, bubbleX, bubbleY, radius);
-                gradient.addColorStop(0, "rgba(214, 244, 255, " + innerAlpha + ")");
-                gradient.addColorStop(0.68, "rgba(154, 216, 255, " + shellAlpha * 0.55 + ")");
+                gradient.addColorStop(0, `rgba(214, 244, 255, ${innerAlpha})`);
+                gradient.addColorStop(0.68, `rgba(154, 216, 255, ${shellAlpha * 0.55})`);
                 gradient.addColorStop(1, 'rgba(120, 200, 255, 0)');
                 ctx.fillStyle = gradient;
                 ctx.beginPath();
                 ctx.arc(bubbleX, bubbleY, radius, 0, Math.PI * 2);
                 ctx.fill();
                 ctx.lineWidth = Math.max(1.1, radius * 0.18);
-                ctx.strokeStyle = "rgba(182, 235, 255, " + (0.26 + twinkle * 0.22) + ")";
+                ctx.strokeStyle = `rgba(182, 235, 255, ${0.26 + twinkle * 0.22})`;
                 ctx.stroke();
             }
             ctx.restore();
@@ -14707,12 +15426,7 @@ document.addEventListener('DOMContentLoaded', () => {
         }
         ctx.restore();
     }
-    function drawBubbleTrailSegments(points, now, options) {
-        const settings = options || {};
-        const baseRadius = settings.baseRadius !== undefined ? settings.baseRadius : 18;
-        const radiusJitter = settings.radiusJitter !== undefined ? settings.radiusJitter : 6;
-        const alphaScale = settings.alphaScale !== undefined ? settings.alphaScale : 1;
-        const sway = settings.sway !== undefined ? settings.sway : 3.4;
+    function drawBubbleTrailSegments(points, now, { baseRadius = 18, radiusJitter = 6, alphaScale = 1, sway = 3.4 } = {}) {
         if (!points || points.length < 2) {
             return;
         }
@@ -14734,15 +15448,15 @@ document.addEventListener('DOMContentLoaded', () => {
             const innerAlpha = 0.32 * fade;
             const midAlpha = 0.18 * fade;
             const gradient = ctx.createRadialGradient(bubbleX, bubbleY, radius * 0.25, bubbleX, bubbleY, radius);
-            gradient.addColorStop(0, "rgba(214, 244, 255, " + innerAlpha + ")");
-            gradient.addColorStop(0.7, "rgba(154, 216, 255, " + midAlpha + ")");
+            gradient.addColorStop(0, `rgba(214, 244, 255, ${innerAlpha})`);
+            gradient.addColorStop(0.7, `rgba(154, 216, 255, ${midAlpha})`);
             gradient.addColorStop(1, 'rgba(120, 200, 255, 0)');
             ctx.fillStyle = gradient;
             ctx.beginPath();
             ctx.arc(bubbleX, bubbleY, radius, 0, Math.PI * 2);
             ctx.fill();
             ctx.lineWidth = Math.max(1, radius * 0.16);
-            ctx.strokeStyle = "rgba(182, 235, 255, " + 0.26 * fade + ")";
+            ctx.strokeStyle = `rgba(182, 235, 255, ${0.26 * fade})`;
             ctx.stroke();
         }
         ctx.restore();
@@ -15282,7 +15996,7 @@ document.addEventListener('DOMContentLoaded', () => {
         ctx.restore();
     }
     function drawProjectiles() {
-        var _a, _b, _c;
+        var _a, _b, _c, _d, _e, _f;
         for (const projectile of projectiles) {
             if (projectile.type === 'missile') {
                 ctx.save();
@@ -15368,6 +16082,92 @@ document.addEventListener('DOMContentLoaded', () => {
                     ctx.strokeStyle = 'rgba(255, 244, 214, 0.38)';
                     ctx.lineWidth = 1.2;
                     ctx.stroke();
+                    ctx.globalCompositeOperation = 'source-over';
+                }
+                else if (projectile.type === 'cyclone') {
+                    const colors = Array.isArray(projectile.gradient) && projectile.gradient.length
+                        ? projectile.gradient
+                        : ['#bae6fd', '#38bdf8', '#0ea5e9'];
+                    const gradient = ctx.createLinearGradient(projectile.x, projectile.y, projectile.x + projectile.width, projectile.y + projectile.height);
+                    colors.forEach((color, index) => {
+                        const stop = colors.length > 1 ? index / (colors.length - 1) : 0;
+                        gradient.addColorStop(stop, color);
+                    });
+                    ctx.globalCompositeOperation = 'lighter';
+                    ctx.fillStyle = gradient;
+                    const halfHeight = projectile.height * 0.5;
+                    const curve = (_d = projectile.curve) !== null && _d !== void 0 ? _d : 0;
+                    ctx.beginPath();
+                    ctx.moveTo(projectile.x, projectile.y + halfHeight);
+                    ctx.quadraticCurveTo(projectile.x + projectile.width * 0.28, projectile.y + halfHeight - curve * 0.6, projectile.x + projectile.width * 0.5, projectile.y + halfHeight + curve * 0.5);
+                    ctx.quadraticCurveTo(projectile.x + projectile.width * 0.82, projectile.y + halfHeight - curve * 0.3, projectile.x + projectile.width, projectile.y + halfHeight);
+                    ctx.quadraticCurveTo(projectile.x + projectile.width * 0.7, projectile.y + halfHeight + curve * 0.45, projectile.x + projectile.width * 0.32, projectile.y + halfHeight - curve * 0.45);
+                    ctx.closePath();
+                    ctx.fill();
+                    if (projectile.glow) {
+                        ctx.strokeStyle = projectile.glow;
+                        ctx.lineWidth = 1.1;
+                        ctx.stroke();
+                    }
+                    ctx.globalCompositeOperation = 'source-over';
+                }
+                else if (projectile.type === 'nebula') {
+                    const gradient = ctx.createRadialGradient(projectile.x + projectile.width * 0.5, projectile.y + projectile.height * 0.5, Math.max(4, Math.min(projectile.width, projectile.height) * 0.2), projectile.x + projectile.width * 0.5, projectile.y + projectile.height * 0.5, Math.max(projectile.width, projectile.height) * 0.6);
+                    const colors = Array.isArray(projectile.gradient) && projectile.gradient.length
+                        ? projectile.gradient
+                        : ['rgba(236, 72, 153, 0.85)', 'rgba(168, 85, 247, 0.55)', 'rgba(59, 130, 246, 0.18)'];
+                    colors.forEach((color, index) => {
+                        const stop = colors.length > 1 ? index / (colors.length - 1) : 0;
+                        gradient.addColorStop(stop, color);
+                    });
+                    ctx.save();
+                    ctx.globalCompositeOperation = 'lighter';
+                    ctx.fillStyle = gradient;
+                    const centerX = projectile.x + projectile.width * 0.5;
+                    const centerY = projectile.y + projectile.height * 0.5;
+                    const scale = (_e = projectile.pulseScale) !== null && _e !== void 0 ? _e : 1;
+                    ctx.translate(centerX, centerY);
+                    ctx.scale(scale, Math.max(0.7, scale * 0.85));
+                    const radius = Math.max(projectile.width, projectile.height) * 0.4;
+                    ctx.beginPath();
+                    ctx.ellipse(0, 0, radius * 1.1, radius, 0, 0, Math.PI * 2);
+                    ctx.fill();
+                    ctx.restore();
+                    ctx.globalCompositeOperation = 'source-over';
+                }
+                else if (projectile.type === 'quasar') {
+                    const centerX = projectile.x + projectile.width * 0.5;
+                    const centerY = projectile.y + projectile.height * 0.5;
+                    const radius = Math.max(projectile.width, projectile.height) * 0.5;
+                    const gradient = ctx.createRadialGradient(centerX, centerY, radius * 0.1, centerX, centerY, radius);
+                    gradient.addColorStop(0, 'rgba(251, 191, 36, 0.95)');
+                    gradient.addColorStop(0.5, 'rgba(249, 115, 22, 0.6)');
+                    gradient.addColorStop(1, 'rgba(59, 130, 246, 0.25)');
+                    ctx.save();
+                    ctx.globalCompositeOperation = 'lighter';
+                    ctx.translate(centerX, centerY);
+                    const spin = (_f = projectile.spin) !== null && _f !== void 0 ? _f : 0;
+                    ctx.rotate(spin);
+                    ctx.fillStyle = gradient;
+                    const points = 6;
+                    const innerRadius = radius * 0.42;
+                    ctx.beginPath();
+                    for (let arm = 0; arm < points; arm++) {
+                        const outerAngle = (Math.PI * 2 * arm) / points;
+                        const innerAngle = outerAngle + Math.PI / points;
+                        const outerX = Math.cos(outerAngle) * radius;
+                        const outerY = Math.sin(outerAngle) * radius;
+                        if (arm === 0) {
+                            ctx.moveTo(outerX, outerY);
+                        }
+                        else {
+                            ctx.lineTo(outerX, outerY);
+                        }
+                        ctx.lineTo(Math.cos(innerAngle) * innerRadius, Math.sin(innerAngle) * innerRadius);
+                    }
+                    ctx.closePath();
+                    ctx.fill();
+                    ctx.restore();
                     ctx.globalCompositeOperation = 'source-over';
                 }
                 else {
@@ -15465,6 +16265,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     function stepRunning(delta) {
         state.elapsedTime += delta;
+        progressionSystem.addExperience(delta, { source: 'time' });
         const activeChallengeManager = getChallengeManager();
         if (activeChallengeManager) {
             activeChallengeManager.recordEvent('time', { totalMs: state.elapsedTime });

--- a/public/AstroCats3/scripts/app.source.js
+++ b/public/AstroCats3/scripts/app.source.js
@@ -252,6 +252,125 @@ Object.assign(weaponLoadouts, {
         pattern(createProjectile) {
             createProjectile(0, 'lance', { applyLoadoutSpeed: false, audioType: 'lance' });
         }
+    },
+    cyclone: {
+        id: 'cyclone',
+        name: 'Cyclone Twinstorm',
+        icon: 'assets/weapon-cyclone.svg',
+        rarity: 'legendary',
+        summary: 'Twin plasma ribbons spiral forward and wrap around threats.',
+        description:
+            'A tournament-grade emitter that spins paired bolts into a corkscrew. Excellent for carving tunnels through dense asteroid formations.',
+        highlights: [
+            'Fires two weaving projectiles that sweep a wide channel.',
+            'Maintains a brisk firing cadence despite the spiral arc.',
+            'Stacks power with strength-focused pilots for consistent pressure.'
+        ],
+        cooldownMultiplier: 0.94,
+        speedMultiplier: 1.08,
+        createPatternState: () => ({ spin: 0 }),
+        resetPatternState() {},
+        pattern(createProjectile, context = {}) {
+            const state = context?.state ?? context;
+            if (state.spin == null) {
+                state.spin = 0;
+            }
+            state.spin += 1;
+            const phase = (state.spin % 360) * (Math.PI / 180);
+            createProjectile(-0.2, 'cyclone', {
+                wavePhase: phase,
+                waveFrequency: 8.2,
+                waveAmplitude: 18,
+                waveDrift: 28,
+                audioType: 'scatter'
+            });
+            createProjectile(0.2, 'cyclone', {
+                wavePhase: phase + Math.PI,
+                waveFrequency: 8.2,
+                waveAmplitude: 18,
+                waveDrift: 28,
+                audioType: 'scatter'
+            });
+        }
+    },
+    nebula: {
+        id: 'nebula',
+        name: 'Nebula Bloom',
+        icon: 'assets/weapon-nebula.svg',
+        rarity: 'legendary',
+        summary: 'Pulsing plasma orbs drift forward and destabilise nearby foes.',
+        description:
+            'Condenses stellar dust into luminous orbs that pulse with gravitational shear. The slow march belies a devastating area sweep.',
+        highlights: [
+            'Launches dual orbs that pulse outward for reliable lane coverage.',
+            'Innate damage boost makes pickups and bosses melt faster.',
+            'Pairs beautifully with focus-heavy pilots chasing EXP bonuses.'
+        ],
+        cooldownMultiplier: 1.22,
+        speedMultiplier: 0.9,
+        createPatternState: () => ({ step: 0 }),
+        resetPatternState() {},
+        pattern(createProjectile, context = {}) {
+            const state = context?.state ?? context;
+            state.step = (state.step ?? 0) + 1;
+            const offset = ((state.step % 4) - 1.5) * 16;
+            createProjectile(0, 'nebula', {
+                offsetY: offset,
+                speedMultiplier: 0.94,
+                audioType: 'missile',
+                damage: 2
+            });
+            createProjectile(0, 'nebula', {
+                offsetY: -offset,
+                speedMultiplier: 0.94,
+                audioType: 'missile',
+                damage: 2
+            });
+        }
+    },
+    quasar: {
+        id: 'quasar',
+        name: 'Quasar Singularity',
+        icon: 'assets/weapon-quasar.svg',
+        rarity: 'mythic',
+        summary: 'Charged starbursts that detonate with overwhelming force.',
+        description:
+            'Harnesses a micro-singularity to fire unstable stars. Each detonation carves a path through elite foes and bosses alike.',
+        highlights: [
+            'High-impact star cores that cleave through shielded enemies.',
+            'Fires in charged bursts—time your volleys for maximum impact.',
+            'Rewarding payoff for resilience-focused pilots holding long combos.'
+        ],
+        cooldownMultiplier: 1.38,
+        speedMultiplier: 1.02,
+        createPatternState: () => ({ charge: 0 }),
+        resetPatternState() {},
+        pattern(createProjectile, context = {}) {
+            const state = context?.state ?? context;
+            state.charge = (state.charge ?? 0) + 1;
+            createProjectile(0, 'quasar', {
+                audioType: 'lance',
+                damage: 3,
+                life: 2600,
+                speedMultiplier: 1.05
+            });
+            if (state.charge % 3 === 0) {
+                createProjectile(0.14, 'quasar', {
+                    offsetY: 18,
+                    audioType: 'lance',
+                    damage: 3,
+                    life: 2400,
+                    speedMultiplier: 1.04
+                });
+                createProjectile(-0.14, 'quasar', {
+                    offsetY: -18,
+                    audioType: 'lance',
+                    damage: 3,
+                    life: 2400,
+                    speedMultiplier: 1.04
+                });
+            }
+        }
     }
 });
 
@@ -2288,6 +2407,39 @@ document.addEventListener('DOMContentLoaded', () => {
             shadowBlur: 16,
             shadowColor: 'rgba(56, 189, 248, 0.36)'
         },
+        cyclone: {
+            width: 26,
+            height: 18,
+            speedMultiplier: 1.04,
+            life: 2000,
+            damage: 1,
+            gradient: ['#bae6fd', '#38bdf8', '#0ea5e9'],
+            glow: 'rgba(14, 165, 233, 0.52)',
+            shadowBlur: 14,
+            shadowColor: 'rgba(14, 165, 233, 0.32)'
+        },
+        nebula: {
+            width: 34,
+            height: 24,
+            speedMultiplier: 0.92,
+            life: 2600,
+            damage: 2,
+            gradient: ['rgba(236, 72, 153, 0.9)', 'rgba(168, 85, 247, 0.6)', 'rgba(59, 130, 246, 0.25)'],
+            glow: 'rgba(168, 85, 247, 0.55)',
+            shadowBlur: 18,
+            shadowColor: 'rgba(129, 140, 248, 0.32)'
+        },
+        quasar: {
+            width: 30,
+            height: 30,
+            speedMultiplier: 0.96,
+            life: 2400,
+            damage: 3,
+            gradient: ['rgba(253, 230, 138, 0.95)', 'rgba(251, 191, 36, 0.75)', 'rgba(59, 130, 246, 0.28)'],
+            glow: 'rgba(251, 191, 36, 0.6)',
+            shadowBlur: 20,
+            shadowColor: 'rgba(251, 191, 36, 0.4)'
+        },
         flameWhip: {
             width: 48,
             height: 26,
@@ -2346,6 +2498,11 @@ document.addEventListener('DOMContentLoaded', () => {
     const pilotLevelEl = document.getElementById('pilotLevel');
     const pilotExpEl = document.getElementById('pilotExp');
     const pilotStatPointsEl = document.getElementById('pilotStatPoints');
+    const skillTreeSection = document.getElementById('skillTree');
+    const skillTreeListEl = document.getElementById('skillNodeList');
+    const skillTreeHintEl = document.getElementById('skillTreeHint');
+    let skillTreeMessageTimer = null;
+
     const comboFillEl = document.getElementById('comboFill');
     const comboMeterEl = document.getElementById('comboMeter');
     const joystickZone = document.getElementById('joystickZone');
@@ -2368,6 +2525,96 @@ document.addEventListener('DOMContentLoaded', () => {
         statPoints: null,
         rank: null
     };
+
+    function renderSkillTreeUI() {
+        if (!(skillTreeListEl instanceof HTMLElement)) {
+            return;
+        }
+        const state = progressionSystem.getState();
+        const availablePoints = state?.statPoints ?? 0;
+        const allocations = state?.skillAllocations ?? {};
+        skillTreeListEl.textContent = '';
+        for (const node of SKILL_TREE_NODES) {
+            const rank = allocations[node.id] ?? 0;
+            const item = document.createElement('li');
+            item.className = 'skill-node';
+            item.dataset.skillId = node.id;
+            if (rank >= node.maxRank) {
+                item.classList.add('maxed');
+            }
+
+            const header = document.createElement('div');
+            header.className = 'skill-node-header';
+            const title = document.createElement('span');
+            title.className = 'skill-node-name';
+            title.textContent = node.label;
+            const rankEl = document.createElement('span');
+            rankEl.className = 'skill-node-rank';
+            rankEl.textContent = `${rank}/${node.maxRank}`;
+            header.append(title, rankEl);
+            item.appendChild(header);
+
+            const description = document.createElement('p');
+            description.className = 'skill-node-description';
+            description.textContent = node.description;
+            item.appendChild(description);
+
+            if (typeof node.effectText === 'function') {
+                const effect = document.createElement('p');
+                effect.className = 'skill-node-effect';
+                effect.textContent = node.effectText(rank);
+                item.appendChild(effect);
+            }
+
+            const button = document.createElement('button');
+            button.type = 'button';
+            button.className = 'skill-node-upgrade';
+            button.dataset.skillUpgrade = node.id;
+            const isMaxed = rank >= node.maxRank;
+            button.textContent = isMaxed ? 'Maxed' : 'Invest';
+            const shouldDisable = isMaxed || availablePoints <= 0;
+            button.disabled = shouldDisable;
+            button.setAttribute('aria-disabled', shouldDisable ? 'true' : 'false');
+            item.appendChild(button);
+
+            skillTreeListEl.appendChild(item);
+        }
+
+        if (skillTreeHintEl instanceof HTMLElement && !skillTreeHintEl.classList.contains('message')) {
+            const available = availablePoints > 0;
+            skillTreeHintEl.textContent = available
+                ? availablePoints === 1
+                    ? '1 point available to invest.'
+                    : `${availablePoints} points available to invest.`
+                : 'Earn EXP in flights to unlock more stat points.';
+            skillTreeHintEl.classList.toggle('available', available);
+            skillTreeHintEl.dataset.status = available ? 'available' : '';
+        }
+
+        if (skillTreeSection instanceof HTMLElement) {
+            skillTreeSection.hidden = false;
+        }
+    }
+
+    function showSkillTreeMessage(message, type = 'info') {
+        if (!(skillTreeHintEl instanceof HTMLElement) || !message) {
+            return;
+        }
+        if (skillTreeMessageTimer != null) {
+            window.clearTimeout(skillTreeMessageTimer);
+            skillTreeMessageTimer = null;
+        }
+        skillTreeHintEl.textContent = message;
+        skillTreeHintEl.dataset.status = type;
+        skillTreeHintEl.classList.add('message');
+        skillTreeHintEl.classList.remove('available');
+        skillTreeMessageTimer = window.setTimeout(() => {
+            skillTreeHintEl.classList.remove('message');
+            skillTreeHintEl.dataset.status = '';
+            skillTreeMessageTimer = null;
+            renderSkillTreeUI();
+        }, 4200);
+    }
 
     function syncPilotTelemetry() {
         if (pilotLevelEl) {
@@ -2426,6 +2673,20 @@ document.addEventListener('DOMContentLoaded', () => {
         }
 
         syncPilotTelemetry();
+    }
+
+    function updateProgressionTelemetry() {
+        const state = progressionSystem.getState();
+        if (!state) {
+            return;
+        }
+        applySharedProfile({
+            level: state.level,
+            exp: state.exp,
+            maxExp: getExpRequirement(state.level),
+            statPoints: state.statPoints,
+            rank: getRankLabel(state.level)
+        });
     }
 
     applySharedProfile();
@@ -4335,7 +4596,8 @@ document.addEventListener('DOMContentLoaded', () => {
         challenges: 'nyanEscape.challenges',
         deviceId: 'nyanEscape.deviceId',
         customLoadouts: 'nyanEscape.customLoadouts',
-        metaProgress: 'nyanEscape.metaProgress'
+        metaProgress: 'nyanEscape.metaProgress',
+        progression: 'nyanEscape.progression'
     };
 
     var storageAvailable = false;
@@ -4370,6 +4632,451 @@ document.addEventListener('DOMContentLoaded', () => {
             storageAvailable = false;
         }
     }
+
+    const LEVEL_CAP = 60;
+    const SKILL_TREE_NODES = [
+        {
+            id: 'strength',
+            label: 'Plasma Strength',
+            description: 'Supercharge the ship\'s primary cannons with heavier impact.',
+            maxRank: 12,
+            effectText(rank) {
+                const bonus = Math.round(rank * 6);
+                return `+${bonus}% projectile damage`;
+            }
+        },
+        {
+            id: 'agility',
+            label: 'Velocity Weave',
+            description: 'Tighten reactor timing to reduce weapon cooldowns.',
+            maxRank: 10,
+            effectText(rank) {
+                const bonus = Math.round(rank * 8);
+                return `-${bonus}% firing cooldown`;
+            }
+        },
+        {
+            id: 'focus',
+            label: 'Quantum Focus',
+            description: 'Accelerate bolts and channel additional combat telemetry.',
+            maxRank: 10,
+            effectText(rank) {
+                const speed = Math.round(rank * 5);
+                const exp = Math.round(rank * 3);
+                return `+${speed}% projectile speed, +${exp}% EXP gain`;
+            }
+        },
+        {
+            id: 'resilience',
+            label: 'Flux Shielding',
+            description: 'Stabilise combo timing and amplify score streak payouts.',
+            maxRank: 10,
+            effectText(rank) {
+                const windowBonus = Math.round(rank * 6);
+                const scoreBonus = Math.round(rank * 2);
+                return `+${windowBonus}% combo window, +${scoreBonus}% score`;
+            }
+        }
+    ];
+    const SKILL_NODE_INDEX = new Map(SKILL_TREE_NODES.map((node) => [node.id, node]));
+    const WEAPON_UNLOCK_RULES = [
+        { level: 2, weaponId: 'scatter' },
+        { level: 4, weaponId: 'lance' },
+        { level: 6, weaponId: 'cyclone' },
+        { level: 8, weaponId: 'nebula' },
+        { level: 12, weaponId: 'quasar' }
+    ];
+
+    function getWeaponUnlockRequirement(weaponId) {
+        const rule = WEAPON_UNLOCK_RULES.find((entry) => entry.weaponId === weaponId);
+        return rule ? rule.level : null;
+    }
+
+    let progressionState = null;
+    const progressionEffects = {
+        damageMultiplier: 1,
+        projectileSpeedMultiplier: 1,
+        cooldownMultiplier: 1,
+        comboWindowMultiplier: 1,
+        scoreMultiplier: 1,
+        expGainMultiplier: 1
+    };
+    let experienceCarryover = 0;
+    let updateProgressionTelemetryHook = null;
+    let renderSkillTreeHook = null;
+    let skillTreeMessageHook = null;
+
+    function getExpRequirement(level) {
+        const normalized = Math.max(1, Math.min(LEVEL_CAP, Number.isFinite(level) ? Math.floor(level) : 1));
+        const base = 320;
+        const curve = Math.pow(normalized + 4, 1.6) * 18;
+        return Math.max(120, Math.round(base + curve));
+    }
+
+    function getRankLabel(level) {
+        if (level >= 40) {
+            return 'Galaxy Legend';
+        }
+        if (level >= 30) {
+            return 'Star Commodore';
+        }
+        if (level >= 20) {
+            return 'Wing Commander';
+        }
+        if (level >= 10) {
+            return 'Squad Ace';
+        }
+        if (level >= 5) {
+            return 'Senior Cadet';
+        }
+        return 'Flight Cadet';
+    }
+
+    function createDefaultProgressionState() {
+        const allocations = {};
+        for (const node of SKILL_TREE_NODES) {
+            allocations[node.id] = 0;
+        }
+        return {
+            version: 1,
+            level: 1,
+            exp: 0,
+            totalExp: 0,
+            statPoints: 2,
+            skillAllocations: allocations,
+            unlockedWeapons: ['pulse']
+        };
+    }
+
+    function normalizeProgressionState(raw) {
+        const defaults = createDefaultProgressionState();
+        if (!raw || typeof raw !== 'object') {
+            return defaults;
+        }
+        const state = {
+            version: 1,
+            level: Number.isFinite(raw.level) ? Math.max(1, Math.min(LEVEL_CAP, Math.floor(raw.level))) : defaults.level,
+            exp: Number.isFinite(raw.exp) ? Math.max(0, Math.floor(raw.exp)) : defaults.exp,
+            totalExp: Number.isFinite(raw.totalExp) ? Math.max(0, Math.floor(raw.totalExp)) : defaults.totalExp,
+            statPoints: Number.isFinite(raw.statPoints) ? Math.max(0, Math.floor(raw.statPoints)) : defaults.statPoints,
+            skillAllocations: { ...defaults.skillAllocations },
+            unlockedWeapons: Array.isArray(raw.unlockedWeapons)
+                ? Array.from(new Set(raw.unlockedWeapons.map((value) => String(value)))).filter(Boolean)
+                : [...defaults.unlockedWeapons]
+        };
+        for (const node of SKILL_TREE_NODES) {
+            const rank = Number.isFinite(raw.skillAllocations?.[node.id])
+                ? Math.max(0, Math.min(node.maxRank, Math.floor(raw.skillAllocations[node.id])))
+                : defaults.skillAllocations[node.id];
+            state.skillAllocations[node.id] = rank;
+        }
+        return state;
+    }
+
+    function loadProgressionState() {
+        if (!storageAvailable) {
+            return normalizeProgressionState(null);
+        }
+        try {
+            const raw = readStorage(STORAGE_KEYS.progression);
+            if (!raw) {
+                return normalizeProgressionState(null);
+            }
+            const parsed = JSON.parse(raw);
+            return normalizeProgressionState(parsed);
+        } catch (error) {
+            return normalizeProgressionState(null);
+        }
+    }
+
+    function persistProgressionState() {
+        if (!storageAvailable || !progressionState) {
+            return;
+        }
+        try {
+            const payload = {
+                version: 1,
+                level: progressionState.level,
+                exp: progressionState.exp,
+                totalExp: progressionState.totalExp,
+                statPoints: progressionState.statPoints,
+                skillAllocations: { ...progressionState.skillAllocations },
+                unlockedWeapons: Array.from(new Set(progressionState.unlockedWeapons.map((value) => String(value))))
+            };
+            writeStorage(STORAGE_KEYS.progression, JSON.stringify(payload));
+        } catch (error) {
+            // Ignore persistence errors
+        }
+    }
+
+    function recalcProgressionEffects() {
+        const strength = progressionState?.skillAllocations?.strength ?? 0;
+        const agility = progressionState?.skillAllocations?.agility ?? 0;
+        const focus = progressionState?.skillAllocations?.focus ?? 0;
+        const resilience = progressionState?.skillAllocations?.resilience ?? 0;
+        progressionEffects.damageMultiplier = 1 + strength * 0.06;
+        progressionEffects.cooldownMultiplier = 1 / (1 + agility * 0.08);
+        progressionEffects.projectileSpeedMultiplier = 1 + focus * 0.05;
+        progressionEffects.expGainMultiplier = 1 + focus * 0.03;
+        progressionEffects.comboWindowMultiplier = 1 + resilience * 0.06;
+        progressionEffects.scoreMultiplier = 1 + resilience * 0.02;
+    }
+
+    function pushSkillTreeMessage(message, type = 'info') {
+        if (typeof skillTreeMessageHook === 'function' && message) {
+            try {
+                skillTreeMessageHook(message, type);
+            } catch (error) {
+                console.error('skill tree message error', error);
+            }
+        }
+    }
+
+    function syncProgressionToCosmetics({ silent = false } = {}) {
+        if (typeof ensureCosmeticsState !== 'function') {
+            return;
+        }
+        const cosmetics = ensureCosmeticsState();
+        if (!Array.isArray(cosmetics.ownedWeapons)) {
+            cosmetics.ownedWeapons = [];
+        }
+        const ownedSet = new Set(cosmetics.ownedWeapons.map((value) => String(value)));
+        let changed = false;
+        for (const weaponId of progressionState.unlockedWeapons) {
+            if (!ownedSet.has(weaponId)) {
+                cosmetics.ownedWeapons.push(weaponId);
+                ownedSet.add(weaponId);
+                changed = true;
+            }
+        }
+        for (const weaponId of cosmetics.ownedWeapons) {
+            if (!progressionState.unlockedWeapons.includes(weaponId)) {
+                progressionState.unlockedWeapons.push(weaponId);
+                changed = true;
+            }
+        }
+        if (changed && !silent) {
+            persistProgressionState();
+        }
+    }
+
+    function unlockWeaponsForLevel(level, { announce = false } = {}) {
+        const unlocked = [];
+        for (const rule of WEAPON_UNLOCK_RULES) {
+            if (level >= rule.level && !progressionState.unlockedWeapons.includes(rule.weaponId)) {
+                progressionState.unlockedWeapons.push(rule.weaponId);
+                unlocked.push(rule.weaponId);
+            }
+        }
+        if (unlocked.length) {
+            syncProgressionToCosmetics({ silent: true });
+            persistProgressionState();
+            if (announce) {
+                for (const weaponId of unlocked) {
+                    const definition = typeof getWeaponDefinition === 'function' ? getWeaponDefinition(weaponId) : null;
+                    const name = definition?.name ?? weaponId;
+                    pushSkillTreeMessage(`Unlocked weapon: ${name}`, 'success');
+                }
+                try {
+                    if (typeof renderWeaponSelectGrid === 'function') {
+                        renderWeaponSelectGrid();
+                    }
+                } catch (error) {
+                    console.error('weapon grid refresh failed', error);
+                }
+                try {
+                    if (typeof updatePreflightSummary === 'function') {
+                        updatePreflightSummary();
+                    }
+                } catch (error) {
+                    console.error('preflight summary refresh failed', error);
+                }
+            }
+        }
+        return unlocked;
+    }
+
+    function updateProgressionHooks({ announce = false } = {}) {
+        recalcProgressionEffects();
+        if (typeof updateProgressionTelemetryHook === 'function') {
+            try {
+                updateProgressionTelemetryHook();
+            } catch (error) {
+                console.error('progression telemetry update error', error);
+            }
+        }
+        if (typeof renderSkillTreeHook === 'function') {
+            try {
+                renderSkillTreeHook();
+            } catch (error) {
+                console.error('skill tree render error', error);
+            }
+        }
+        if (announce) {
+            const rank = getRankLabel(progressionState.level);
+            pushSkillTreeMessage(`Level ${progressionState.level} — ${rank}`, 'success');
+        }
+    }
+
+    function addProgressionExperience(amount, { source = 'score' } = {}) {
+        const numeric = Number(amount);
+        if (!Number.isFinite(numeric) || numeric <= 0 || !progressionState) {
+            return 0;
+        }
+        const rates = {
+            score: 1 / 28,
+            dodge: 1 / 18,
+            time: 0.08 / 1000,
+            boss: 12
+        };
+        const rate = rates[source] ?? rates.score;
+        const scaled = numeric * rate * progressionEffects.expGainMultiplier;
+        experienceCarryover += scaled;
+        const whole = Math.floor(experienceCarryover);
+        if (whole <= 0) {
+            return 0;
+        }
+        experienceCarryover -= whole;
+        let remaining = whole;
+        let leveled = false;
+        progressionState.totalExp += whole;
+        while (remaining > 0) {
+            const requirement = getExpRequirement(progressionState.level);
+            const needed = requirement - progressionState.exp;
+            if (remaining >= needed && progressionState.level < LEVEL_CAP) {
+                progressionState.exp = 0;
+                progressionState.level = Math.min(LEVEL_CAP, progressionState.level + 1);
+                progressionState.statPoints += 2;
+                remaining -= needed;
+                leveled = true;
+            } else {
+                progressionState.exp = Math.min(requirement, progressionState.exp + remaining);
+                remaining = 0;
+            }
+            if (progressionState.level >= LEVEL_CAP) {
+                progressionState.exp = Math.min(getExpRequirement(LEVEL_CAP), progressionState.exp);
+                remaining = 0;
+            }
+        }
+        persistProgressionState();
+        const unlocked = unlockWeaponsForLevel(progressionState.level, { announce: leveled });
+        updateProgressionHooks({ announce: leveled });
+        if (!leveled && unlocked.length) {
+            for (const weaponId of unlocked) {
+                const definition = typeof getWeaponDefinition === 'function' ? getWeaponDefinition(weaponId) : null;
+                const name = definition?.name ?? weaponId;
+                pushSkillTreeMessage(`Unlocked weapon: ${name}`, 'success');
+            }
+        }
+        return whole;
+    }
+
+    function allocateSkillPoint(skillId) {
+        if (!progressionState) {
+            return false;
+        }
+        const node = SKILL_NODE_INDEX.get(skillId);
+        if (!node) {
+            return false;
+        }
+        const current = progressionState.skillAllocations[skillId] ?? 0;
+        if (current >= node.maxRank || progressionState.statPoints <= 0) {
+            return false;
+        }
+        progressionState.skillAllocations[skillId] = current + 1;
+        progressionState.statPoints -= 1;
+        persistProgressionState();
+        recalcProgressionEffects();
+        if (typeof renderSkillTreeHook === 'function') {
+            try {
+                renderSkillTreeHook();
+            } catch (error) {
+                console.error('skill tree render error', error);
+            }
+        }
+        if (typeof updateProgressionTelemetryHook === 'function') {
+            try {
+                updateProgressionTelemetryHook();
+            } catch (error) {
+                console.error('progression telemetry update error', error);
+            }
+        }
+        const effectText = node.effectText ? node.effectText(progressionState.skillAllocations[skillId]) : '';
+        const message = effectText ? `${node.label} upgraded — ${effectText}` : `${node.label} upgraded`;
+        pushSkillTreeMessage(message, 'success');
+        return true;
+    }
+
+    function getProgressionState() {
+        return progressionState;
+    }
+
+    function setProgressionTelemetryUpdater(fn) {
+        updateProgressionTelemetryHook = typeof fn === 'function' ? fn : null;
+    }
+
+    function setSkillTreeRenderer(fn) {
+        renderSkillTreeHook = typeof fn === 'function' ? fn : null;
+    }
+
+    function setSkillTreeMessenger(fn) {
+        skillTreeMessageHook = typeof fn === 'function' ? fn : null;
+    }
+
+    progressionState = loadProgressionState();
+    const requiredExp = getExpRequirement(progressionState.level);
+    if (progressionState.exp >= requiredExp && progressionState.level < LEVEL_CAP) {
+        const surplus = Math.floor(progressionState.exp / requiredExp);
+        progressionState.level = Math.min(LEVEL_CAP, progressionState.level + surplus);
+        progressionState.statPoints += surplus * 2;
+        progressionState.exp = progressionState.exp % requiredExp;
+    } else if (progressionState.level >= LEVEL_CAP) {
+        progressionState.level = LEVEL_CAP;
+        progressionState.exp = Math.min(getExpRequirement(LEVEL_CAP), progressionState.exp);
+    }
+    syncProgressionToCosmetics({ silent: true });
+    unlockWeaponsForLevel(progressionState.level, { announce: false });
+    recalcProgressionEffects();
+
+    const progressionSystem = {
+        addExperience: addProgressionExperience,
+        allocateSkillPoint,
+        getState: getProgressionState,
+        getEffects: () => ({ ...progressionEffects }),
+        syncCosmetics: syncProgressionToCosmetics
+    };
+
+    if (typeof window !== 'undefined') {
+        window.astrocatProgression = progressionSystem;
+        window.registerProgressionTelemetryUpdater = setProgressionTelemetryUpdater;
+        window.registerSkillTreeRenderer = setSkillTreeRenderer;
+        window.registerSkillTreeMessenger = setSkillTreeMessenger;
+    }
+
+    setSkillTreeRenderer(renderSkillTreeUI);
+    setSkillTreeMessenger(showSkillTreeMessage);
+
+    if (skillTreeListEl) {
+        skillTreeListEl.addEventListener('click', (event) => {
+            const target = event.target instanceof HTMLElement ? event.target : null;
+            const button = target?.closest('[data-skill-upgrade]');
+            if (!(button instanceof HTMLButtonElement) || button.disabled) {
+                return;
+            }
+            const skillId = button.dataset.skillUpgrade ?? '';
+            if (!skillId) {
+                return;
+            }
+            const upgraded = progressionSystem.allocateSkillPoint(skillId);
+            if (!upgraded) {
+                showSkillTreeMessage('Need more stat points. Fly missions to earn EXP.', 'warning');
+            }
+        });
+    }
+
+    setProgressionTelemetryUpdater(updateProgressionTelemetry);
+    renderSkillTreeUI();
+    updateProgressionTelemetry();
 
 const CUSTOM_LOADOUT_VERSION = 1;
 const CUSTOM_LOADOUT_SLOTS = [
@@ -5445,6 +6152,12 @@ const MAX_LOADOUT_NAME_LENGTH = 32;
         }
         weaponCards = [];
         weaponSelectGrid.innerHTML = '';
+        const cosmetics = ensureCosmeticsState();
+        const ownedWeapons = new Set(
+            Array.isArray(cosmetics?.ownedWeapons)
+                ? cosmetics.ownedWeapons.map((value) => String(value))
+                : []
+        );
         for (const weapon of Object.values(weaponLoadouts)) {
             const button = document.createElement('button');
             button.type = 'button';
@@ -5486,17 +6199,32 @@ const MAX_LOADOUT_NAME_LENGTH = 32;
                 button.appendChild(details);
             }
 
-            button.addEventListener('click', () => {
-                pendingWeaponId = weapon.id;
-                updateWeaponSelectionState();
-            });
-            button.addEventListener('keydown', (event) => {
-                if (event.key === 'Enter' || event.key === ' ') {
-                    event.preventDefault();
+            const isUnlocked = ownedWeapons.has(weapon.id);
+            if (!isUnlocked) {
+                button.disabled = true;
+                button.tabIndex = -1;
+                button.setAttribute('aria-disabled', 'true');
+                button.classList.add('locked');
+                const unlockLevel = getWeaponUnlockRequirement(weapon.id);
+                const lockBadge = document.createElement('span');
+                lockBadge.className = 'weapon-lock-badge';
+                lockBadge.textContent = unlockLevel
+                    ? `Unlocks at Level ${unlockLevel}`
+                    : 'Unlock through special events';
+                button.appendChild(lockBadge);
+            } else {
+                button.addEventListener('click', () => {
                     pendingWeaponId = weapon.id;
                     updateWeaponSelectionState();
-                }
-            });
+                });
+                button.addEventListener('keydown', (event) => {
+                    if (event.key === 'Enter' || event.key === ' ') {
+                        event.preventDefault();
+                        pendingWeaponId = weapon.id;
+                        updateWeaponSelectionState();
+                    }
+                });
+            }
 
             weaponSelectGrid.appendChild(button);
             weaponCards.push(button);
@@ -5602,6 +6330,7 @@ const MAX_LOADOUT_NAME_LENGTH = 32;
     }
 
     initializeLoadoutSelections();
+    progressionSystem.syncCosmetics({ silent: true });
     renderPilotSelectGrid();
     renderWeaponSelectGrid();
     renderCustomLoadoutCollections();
@@ -6596,7 +7325,7 @@ const MAX_LOADOUT_NAME_LENGTH = 32;
         return {
             ownedSkins: ['default'],
             ownedTrails: ['rainbow'],
-            ownedWeapons: ['pulse', 'scatter', 'lance'],
+            ownedWeapons: ['pulse'],
             equipped: { skin: 'default', trail: 'rainbow', weapon: 'pulse' }
         };
     }
@@ -12558,8 +13287,12 @@ const MAX_LOADOUT_NAME_LENGTH = 32;
         const loadout = getActiveWeaponLoadout();
         const cooldownMultiplier = loadout?.cooldownMultiplier ?? 1;
         const cooldownOffset = loadout?.cooldownOffset ?? 0;
-        const cooldown = Math.max(60, config.projectileCooldown * cooldownMultiplier + cooldownOffset);
-        if ((keys.has('Space') || virtualInput.firing || gamepadInput.firing) && state.timeSinceLastShot >= cooldown) {
+        const baseCooldown = config.projectileCooldown * cooldownMultiplier + cooldownOffset;
+        const adjustedCooldown = Math.max(40, baseCooldown * progressionEffects.cooldownMultiplier);
+        if (
+            (keys.has('Space') || virtualInput.firing || gamepadInput.firing) &&
+            state.timeSinceLastShot >= adjustedCooldown
+        ) {
             spawnProjectiles();
             state.timeSinceLastShot = 0;
         }
@@ -12592,9 +13325,11 @@ const MAX_LOADOUT_NAME_LENGTH = 32;
             const speedMultiplier =
                 (overrides.speedMultiplier ?? archetype?.speedMultiplier ?? 1) *
                 (applyLoadoutSpeed ? loadoutSpeedMultiplier : 1);
-            const speed = config.projectileSpeed * speedMultiplier;
+            const speed =
+                config.projectileSpeed * speedMultiplier * progressionEffects.projectileSpeedMultiplier;
             const vx = Math.cos(angle) * speed;
             const vy = Math.sin(angle) * speed;
+            const baseDamage = overrides.damage ?? archetype?.damage ?? 1;
             const projectile = {
                 x: originX + (overrides.offsetX ?? 0),
                 y: originY + (overrides.offsetY ?? 0),
@@ -12604,7 +13339,8 @@ const MAX_LOADOUT_NAME_LENGTH = 32;
                 vy,
                 life: overrides.life ?? archetype?.life ?? 2000,
                 type,
-                damage: overrides.damage ?? archetype?.damage ?? 1,
+                damage: baseDamage,
+                baseDamage,
                 gradient: overrides.gradient ?? archetype?.gradient ?? null,
                 glow: overrides.glow ?? archetype?.glow ?? null,
                 shape: overrides.shape ?? archetype?.shape ?? null,
@@ -13260,6 +13996,24 @@ const MAX_LOADOUT_NAME_LENGTH = 32;
                         });
                     }
                 }
+            } else if (projectile.type === 'cyclone') {
+                projectile.waveTime = (projectile.waveTime ?? 0) + delta;
+                const phase = projectile.wavePhase ?? 0;
+                const frequency = projectile.waveFrequency ?? 7.8;
+                const amplitude = projectile.waveAmplitude ?? 16;
+                const drift = projectile.waveDrift ?? 26;
+                const waveSeconds = projectile.waveTime / 1000;
+                projectile.curve = Math.sin(waveSeconds * frequency + phase) * amplitude;
+                projectile.y += Math.cos(waveSeconds * (frequency * 0.6) + phase * 0.4) * drift * deltaSeconds * 0.12;
+            } else if (projectile.type === 'nebula') {
+                projectile.pulseTime = (projectile.pulseTime ?? 0) + delta;
+                const pulseSeconds = projectile.pulseTime / 260;
+                const pulse = Math.sin(pulseSeconds) * 0.3 + 1.05;
+                projectile.pulseScale = pulse;
+                projectile.vy += Math.sin(pulseSeconds * 1.4) * deltaSeconds * 18;
+            } else if (projectile.type === 'quasar') {
+                projectile.spin = (projectile.spin ?? 0) + delta * 0.0042;
+                projectile.pulse = (projectile.pulse ?? 0) + delta * 0.0035;
             }
 
             projectile.x += projectile.vx * deltaSeconds;
@@ -14584,15 +15338,14 @@ const MAX_LOADOUT_NAME_LENGTH = 32;
         if (!projectile) {
             return 1;
         }
-        if (Number.isFinite(projectile.damage)) {
-            return Math.max(1, projectile.damage);
-        }
-        switch (projectile.type) {
-            case 'missile':
-                return 2;
-            default:
-                return 1;
-        }
+        const baseDamage = Number.isFinite(projectile.baseDamage)
+            ? projectile.baseDamage
+            : Number.isFinite(projectile.damage)
+                ? projectile.damage
+                : projectile.type === 'missile'
+                    ? 2
+                    : 1;
+        return Math.max(1, Math.round(baseDamage * progressionEffects.damageMultiplier));
     }
 
     function updateProjectilesCollisions() {
@@ -15150,17 +15903,19 @@ const MAX_LOADOUT_NAME_LENGTH = 32;
     }
 
     function awardDodge() {
-        state.score += config.score.dodge;
+        const dodgePoints = Math.max(1, Math.floor(config.score.dodge * progressionEffects.scoreMultiplier));
+        state.score += dodgePoints;
         state.comboTimer = Math.max(0, state.comboTimer - 400);
         const center = getPlayerCenter();
         spawnFloatingText({
-            text: `+${config.score.dodge} Dodge`,
+            text: `+${dodgePoints} Dodge`,
             x: center.x + player.width * 0.5,
             y: center.y,
             color: '#fde68a',
             life: 900,
             variant: 'dodge'
         });
+        progressionSystem.addExperience(dodgePoints, { source: 'dodge' });
     }
 
     function getVillainEscapePenalty(obstacle) {
@@ -15185,7 +15940,7 @@ const MAX_LOADOUT_NAME_LENGTH = 32;
             });
             triggerScreenShake(8, 240);
         }
-        state.comboTimer = config.comboDecayWindow;
+        state.comboTimer = getComboDecayWindow();
         resetStreak();
         const sparkCenter = getPlayerCenter();
         createHitSpark({
@@ -15222,8 +15977,8 @@ const MAX_LOADOUT_NAME_LENGTH = 32;
         mascotAnnouncer.cheerForCombo(state.streak);
         const comboMultiplier = 1 + state.streak * config.comboMultiplierStep;
         const surgeMultiplier = getScoreSurgeMultiplier();
-        const totalMultiplier = comboMultiplier * surgeMultiplier;
-        const finalPoints = Math.floor(basePoints * totalMultiplier);
+        const totalMultiplier = comboMultiplier * surgeMultiplier * progressionEffects.scoreMultiplier;
+        const finalPoints = Math.max(0, Math.floor(basePoints * totalMultiplier));
         state.score += finalPoints;
         storyManager.recordEvent('score', { totalScore: state.score, deltaScore: finalPoints });
         if (activeChallengeManager) {
@@ -15232,6 +15987,7 @@ const MAX_LOADOUT_NAME_LENGTH = 32;
         if (metaProgressManager) {
             metaProgressManager.recordScore(finalPoints, { totalScore: state.score });
         }
+        progressionSystem.addExperience(finalPoints, { source: 'score' });
         const originX = source.x ?? player.x + player.width * 0.5;
         const originY = source.y ?? player.y;
         const text = `+${finalPoints.toLocaleString()}${totalMultiplier > 1.01 ? ` x${totalMultiplier.toFixed(2)}` : ''}`;
@@ -15246,6 +16002,11 @@ const MAX_LOADOUT_NAME_LENGTH = 32;
         if (finalPoints >= 600) {
             triggerScreenShake(Math.min(16, 6 + finalPoints / 400), 280);
         }
+    }
+
+    function getComboDecayWindow() {
+        const baseWindow = getComboDecayWindow();
+        return Math.max(1000, Math.round(baseWindow * progressionEffects.comboWindowMultiplier));
     }
 
     function resetStreak() {
@@ -15583,10 +16344,11 @@ const MAX_LOADOUT_NAME_LENGTH = 32;
 
     function updateCombo(delta) {
         state.comboTimer += delta;
-        if (state.comboTimer >= config.comboDecayWindow && state.streak > 0) {
+        const comboWindow = getComboDecayWindow();
+        if (state.comboTimer >= comboWindow && state.streak > 0) {
             resetStreak();
         }
-        const ratio = clamp(1 - state.comboTimer / config.comboDecayWindow, 0, 1);
+        const ratio = clamp(1 - state.comboTimer / comboWindow, 0, 1);
         const percentage = Math.round(ratio * 100);
         if (percentage !== lastComboPercent) {
             if (comboFillEl) {
@@ -16562,6 +17324,117 @@ const MAX_LOADOUT_NAME_LENGTH = 32;
                     ctx.lineWidth = 1.2;
                     ctx.stroke();
                     ctx.globalCompositeOperation = 'source-over';
+                } else if (projectile.type === 'cyclone') {
+                    const colors =
+                        Array.isArray(projectile.gradient) && projectile.gradient.length
+                            ? projectile.gradient
+                            : ['#bae6fd', '#38bdf8', '#0ea5e9'];
+                    const gradient = ctx.createLinearGradient(
+                        projectile.x,
+                        projectile.y,
+                        projectile.x + projectile.width,
+                        projectile.y + projectile.height
+                    );
+                    colors.forEach((color, index) => {
+                        const stop = colors.length > 1 ? index / (colors.length - 1) : 0;
+                        gradient.addColorStop(stop, color);
+                    });
+                    ctx.globalCompositeOperation = 'lighter';
+                    ctx.fillStyle = gradient;
+                    const halfHeight = projectile.height * 0.5;
+                    const curve = projectile.curve ?? 0;
+                    ctx.beginPath();
+                    ctx.moveTo(projectile.x, projectile.y + halfHeight);
+                    ctx.quadraticCurveTo(
+                        projectile.x + projectile.width * 0.28,
+                        projectile.y + halfHeight - curve * 0.6,
+                        projectile.x + projectile.width * 0.5,
+                        projectile.y + halfHeight + curve * 0.5
+                    );
+                    ctx.quadraticCurveTo(
+                        projectile.x + projectile.width * 0.82,
+                        projectile.y + halfHeight - curve * 0.3,
+                        projectile.x + projectile.width,
+                        projectile.y + halfHeight
+                    );
+                    ctx.quadraticCurveTo(
+                        projectile.x + projectile.width * 0.7,
+                        projectile.y + halfHeight + curve * 0.45,
+                        projectile.x + projectile.width * 0.32,
+                        projectile.y + halfHeight - curve * 0.45
+                    );
+                    ctx.closePath();
+                    ctx.fill();
+                    if (projectile.glow) {
+                        ctx.strokeStyle = projectile.glow;
+                        ctx.lineWidth = 1.1;
+                        ctx.stroke();
+                    }
+                    ctx.globalCompositeOperation = 'source-over';
+                } else if (projectile.type === 'nebula') {
+                    const gradient = ctx.createRadialGradient(
+                        projectile.x + projectile.width * 0.5,
+                        projectile.y + projectile.height * 0.5,
+                        Math.max(4, Math.min(projectile.width, projectile.height) * 0.2),
+                        projectile.x + projectile.width * 0.5,
+                        projectile.y + projectile.height * 0.5,
+                        Math.max(projectile.width, projectile.height) * 0.6
+                    );
+                    const colors =
+                        Array.isArray(projectile.gradient) && projectile.gradient.length
+                            ? projectile.gradient
+                            : ['rgba(236, 72, 153, 0.85)', 'rgba(168, 85, 247, 0.55)', 'rgba(59, 130, 246, 0.18)'];
+                    colors.forEach((color, index) => {
+                        const stop = colors.length > 1 ? index / (colors.length - 1) : 0;
+                        gradient.addColorStop(stop, color);
+                    });
+                    ctx.save();
+                    ctx.globalCompositeOperation = 'lighter';
+                    ctx.fillStyle = gradient;
+                    const centerX = projectile.x + projectile.width * 0.5;
+                    const centerY = projectile.y + projectile.height * 0.5;
+                    const scale = projectile.pulseScale ?? 1;
+                    ctx.translate(centerX, centerY);
+                    ctx.scale(scale, Math.max(0.7, scale * 0.85));
+                    const radius = Math.max(projectile.width, projectile.height) * 0.4;
+                    ctx.beginPath();
+                    ctx.ellipse(0, 0, radius * 1.1, radius, 0, 0, Math.PI * 2);
+                    ctx.fill();
+                    ctx.restore();
+                    ctx.globalCompositeOperation = 'source-over';
+                } else if (projectile.type === 'quasar') {
+                    const centerX = projectile.x + projectile.width * 0.5;
+                    const centerY = projectile.y + projectile.height * 0.5;
+                    const radius = Math.max(projectile.width, projectile.height) * 0.5;
+                    const gradient = ctx.createRadialGradient(centerX, centerY, radius * 0.1, centerX, centerY, radius);
+                    gradient.addColorStop(0, 'rgba(251, 191, 36, 0.95)');
+                    gradient.addColorStop(0.5, 'rgba(249, 115, 22, 0.6)');
+                    gradient.addColorStop(1, 'rgba(59, 130, 246, 0.25)');
+                    ctx.save();
+                    ctx.globalCompositeOperation = 'lighter';
+                    ctx.translate(centerX, centerY);
+                    const spin = projectile.spin ?? 0;
+                    ctx.rotate(spin);
+                    ctx.fillStyle = gradient;
+                    const points = 6;
+                    const innerRadius = radius * 0.42;
+                    ctx.beginPath();
+                    for (let arm = 0; arm < points; arm++) {
+                        const outerAngle = (Math.PI * 2 * arm) / points;
+                        const innerAngle = outerAngle + Math.PI / points;
+                        const outerX = Math.cos(outerAngle) * radius;
+                        const outerY = Math.sin(outerAngle) * radius;
+                        if (arm === 0) {
+                            ctx.moveTo(outerX, outerY);
+                        } else {
+                            ctx.lineTo(outerX, outerY);
+                        }
+                        ctx.lineTo(Math.cos(innerAngle) * innerRadius, Math.sin(innerAngle) * innerRadius);
+                    }
+                    ctx.closePath();
+                    ctx.fill();
+                    ctx.restore();
+                    ctx.globalCompositeOperation = 'source-over';
                 } else {
                     const colors =
                         Array.isArray(projectile.gradient) && projectile.gradient.length
@@ -16668,6 +17541,7 @@ const MAX_LOADOUT_NAME_LENGTH = 32;
 
     function stepRunning(delta) {
         state.elapsedTime += delta;
+        progressionSystem.addExperience(delta, { source: 'time' });
         const activeChallengeManager = getChallengeManager();
         if (activeChallengeManager) {
             activeChallengeManager.recordEvent('time', { totalMs: state.elapsedTime });

--- a/public/AstroCats3/styles/main.css
+++ b/public/AstroCats3/styles/main.css
@@ -726,6 +726,174 @@ canvas {
     color: #fef3c7;
 }
 
+#stats .skill-tree {
+    border-radius: 18px;
+    border: 1px solid rgba(94, 234, 212, 0.08);
+    background: linear-gradient(150deg, rgba(15, 23, 42, 0.74), rgba(12, 19, 35, 0.68));
+    box-shadow: 0 14px 26px rgba(2, 6, 23, 0.35), inset 0 0 0 1px rgba(56, 189, 248, 0.06);
+    padding: clamp(14px, 2.5vw, 20px);
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+}
+
+#stats .skill-tree-header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 12px;
+}
+
+#stats .skill-tree-title {
+    margin: 0;
+    font-size: 0.82rem;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: rgba(148, 210, 255, 0.82);
+}
+
+#stats .skill-node-list {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: grid;
+    gap: 12px;
+}
+
+#stats .skill-node {
+    border-radius: 14px;
+    border: 1px solid rgba(94, 234, 212, 0.08);
+    padding: 14px 16px;
+    background: linear-gradient(155deg, rgba(12, 22, 44, 0.82), rgba(14, 24, 38, 0.78));
+    box-shadow: inset 0 0 0 1px rgba(56, 189, 248, 0.05);
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+#stats .skill-node.maxed {
+    border-color: rgba(250, 204, 21, 0.4);
+    box-shadow: inset 0 0 0 1px rgba(251, 191, 36, 0.2);
+}
+
+#stats .skill-node-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+}
+
+#stats .skill-node-name {
+    font-weight: 600;
+    font-size: 0.95rem;
+    color: rgba(224, 242, 254, 0.95);
+}
+
+#stats .skill-node-rank {
+    font-size: 0.78rem;
+    color: rgba(148, 210, 255, 0.78);
+    letter-spacing: 0.08em;
+}
+
+#stats .skill-node-description,
+#stats .skill-node-effect {
+    margin: 0;
+    color: rgba(226, 232, 240, 0.8);
+    font-size: 0.82rem;
+    line-height: 1.4;
+}
+
+#stats .skill-node-effect {
+    color: rgba(148, 210, 255, 0.92);
+    font-weight: 600;
+}
+
+#stats .skill-node-upgrade {
+    align-self: flex-start;
+    padding: 8px 16px;
+    border-radius: 999px;
+    border: 1px solid rgba(56, 189, 248, 0.45);
+    background: linear-gradient(135deg, rgba(56, 189, 248, 0.3), rgba(129, 140, 248, 0.28));
+    color: rgba(226, 232, 240, 0.92);
+    font-size: 0.78rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    cursor: pointer;
+    transition: transform 120ms ease, box-shadow 120ms ease, background 160ms ease;
+}
+
+#stats .skill-node-upgrade:hover:not([disabled]) {
+    transform: translateY(-1px);
+    box-shadow: 0 14px 22px rgba(14, 165, 233, 0.28);
+}
+
+#stats .skill-node-upgrade[disabled],
+#stats .skill-node-upgrade[aria-disabled='true'] {
+    cursor: default;
+    opacity: 0.45;
+    background: rgba(71, 85, 105, 0.35);
+    border-color: rgba(71, 85, 105, 0.45);
+}
+
+#stats .skill-tree-hint {
+    margin: 0;
+    font-size: 0.78rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: rgba(148, 163, 184, 0.76);
+    transition: color 140ms ease;
+}
+
+#stats .skill-tree-hint.available {
+    color: rgba(250, 204, 21, 0.86);
+}
+
+#stats .skill-tree-hint.message {
+    color: rgba(226, 232, 240, 0.92);
+}
+
+#stats .skill-tree-hint.message[data-status='success'] {
+    color: rgba(190, 242, 100, 0.95);
+}
+
+#stats .skill-tree-hint.message[data-status='warning'] {
+    color: rgba(252, 211, 77, 0.96);
+}
+
+#stats .skill-tree-hint.message[data-status='info'] {
+    color: rgba(148, 210, 255, 0.9);
+}
+
+.weapon-card.locked {
+    opacity: 0.55;
+    position: relative;
+    pointer-events: none;
+}
+
+.weapon-card.locked img {
+    filter: grayscale(0.6);
+}
+
+.weapon-lock-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    position: absolute;
+    bottom: 12px;
+    left: 12px;
+    right: 12px;
+    padding: 6px 8px;
+    border-radius: 999px;
+    background: rgba(15, 23, 42, 0.72);
+    border: 1px solid rgba(148, 210, 255, 0.32);
+    color: rgba(148, 210, 255, 0.86);
+    font-size: 0.68rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+}
+
+
 #stats .stat-row .value small {
     display: block;
     font-size: 0.72rem;


### PR DESCRIPTION
## Summary
- add player progression system with stat allocation, telemetry updates, and weapon unlock logic
- introduce new legendary weapon loadouts and SVG assets for cyclone, nebula, and quasar patterns
- surface the skill tree UI and styles in the stats panel and sync the compiled runtime script

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d98f0c13b8832480cb022f501fac1b