### PR TITLE
Adjust loadout preview cards

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -1221,23 +1221,13 @@ body.is-scroll-locked {
 .loadout-preview {
   display: grid;
   gap: 12px;
-}
-
-@media (min-width: 720px) {
-  .loadout-preview {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-}
-
-@media (min-width: 960px) {
-  .loadout-preview {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-  }
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  align-items: stretch;
 }
 
 .loadout-preview__item {
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr) auto auto auto;
   gap: 10px;
   padding: 14px;
   border-radius: 18px;
@@ -1245,6 +1235,7 @@ body.is-scroll-locked {
   border: 1px solid rgba(134, 225, 255, 0.18);
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  height: 100%;
 }
 
 .loadout-preview__item:hover {
@@ -1282,6 +1273,7 @@ body.is-scroll-locked {
 .loadout-preview__item--pilot .loadout-preview__media,
 .loadout-preview__item--weapon .loadout-preview__media {
   background: rgba(10, 14, 32, 0.92);
+  aspect-ratio: 1 / 1;
 }
 
 .loadout-preview__image {


### PR DESCRIPTION
## Summary
- restructure the loadout preview grid to auto-fit and stretch cards evenly
- make pilot and weapon preview media square while keeping content alignment consistent

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9b5a434d083249b7d08afc423d9ac