### PR TITLE
Fix pilot stats bars overlapping allocation panel

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -1485,6 +1485,7 @@ body.is-scroll-locked {
   flex-direction: column;
   gap: 6px;
   width: 100%;
+  box-sizing: border-box;
   padding: 14px 16px;
   border-radius: 18px;
   background: rgba(255, 255, 255, 0.06);


### PR DESCRIPTION
## Summary
- ensure pilot stat bar rows use border-box sizing so their bubbles stay within the overview column

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9b5ee18f48324a14dbc982eeeb106