### PR TITLE
Switch mini game loadouts to spacecraft selection

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -1270,7 +1270,7 @@ body.is-scroll-locked {
     0 12px 24px rgba(8, 12, 28, 0.4);
 }
 
-.loadout-preview__item--pilot .loadout-preview__media,
+.loadout-preview__item--spacecraft .loadout-preview__media,
 .loadout-preview__item--weapon .loadout-preview__media {
   background: rgba(10, 14, 32, 0.92);
   aspect-ratio: 1 / 1;


### PR DESCRIPTION
## Summary
- replace pilot loadout options with three spacecraft definitions that include pros, cons, and level requirements
- update the mini game loadout UI to present spacecraft details, enforce unlock gating, and sync changes to the mini game profile
- refresh preview, summary, and option styling/labels to reference spacecraft instead of pilots

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9bb250ed88324a4f02f5ec65bd432