### PR TITLE
Prevent horizontal scrolling inside modals

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -829,6 +829,7 @@ body.is-scroll-locked {
 
 .hud-modal {
   width: min(920px, calc(100% - 32px));
+  max-width: calc(100vw - 48px);
   max-height: min(92vh, 860px);
   background: rgba(14, 22, 52, 0.96);
   border-radius: 24px;
@@ -840,6 +841,7 @@ body.is-scroll-locked {
   gap: 18px;
   color: #f4f6ff;
   box-sizing: border-box;
+  overflow-x: hidden;
 }
 
 .hud-modal__header {
@@ -883,6 +885,7 @@ body.is-scroll-locked {
 .hud-modal__content {
   flex: 1 1 auto;
   overflow-y: auto;
+  overflow-x: hidden;
   padding-right: 6px;
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
@@ -907,6 +910,7 @@ body.is-scroll-locked {
     padding: 24px;
     border-radius: 20px;
     width: 100%;
+    max-width: calc(100vw - 32px);
     max-height: min(92vh, 760px);
   }
 
@@ -2080,6 +2084,7 @@ body.is-scroll-locked {
 
 .onboarding-modal {
   width: min(520px, 100%);
+  max-width: calc(100vw - 64px);
   background: rgba(28, 36, 58, 0.95);
   border-radius: 22px;
   padding: 28px;
@@ -2088,6 +2093,8 @@ body.is-scroll-locked {
   gap: 22px;
   border: 1px solid rgba(120, 150, 255, 0.35);
   box-shadow: 0 30px 60px rgba(10, 16, 35, 0.65);
+  box-sizing: border-box;
+  overflow-x: hidden;
 }
 
 .onboarding-heading {
@@ -2280,6 +2287,7 @@ body.is-scroll-locked {
 
 .minigame-modal {
   width: min(1280px, 100%);
+  max-width: calc(100vw - 64px);
   display: flex;
   flex-direction: column;
   gap: 18px;
@@ -2290,6 +2298,8 @@ body.is-scroll-locked {
   box-shadow:
     0 24px 0 rgba(92, 110, 255, 0.45),
     0 36px 64px rgba(8, 6, 24, 0.55);
+  box-sizing: border-box;
+  overflow-x: hidden;
 }
 
 .minigame-header {
@@ -2388,6 +2398,7 @@ body.is-scroll-locked {
 @media (max-width: 640px) {
   .onboarding-modal {
     padding: 22px;
+    max-width: calc(100vw - 44px);
   }
 
   .onboarding-character {
@@ -2406,6 +2417,7 @@ body.is-scroll-locked {
 
   .minigame-modal {
     padding: 20px;
+    max-width: calc(100vw - 40px);
   }
 
   .minigame-frame {


### PR DESCRIPTION
## Summary
- prevent horizontal overflow in HUD, onboarding, and mini-game modals by constraining their width to the viewport
- include modal padding in width calculations and hide x-axis overflow to keep content snug without side scrolling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9bca5657c8324bd533048905b8c68