### PR TITLE
Add parallax-scrolling background to lobby

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1237,6 +1237,36 @@ const backgroundImage = new Image();
 const backgroundSource = backgroundImageUrl;
 let backgroundReady = false;
 let backgroundDimensions = { width: 0, height: 0 };
+let parallaxScroll = 0;
+const parallaxStarfield = createStarfield(140);
+const parallaxRidgeLayers = [
+  {
+    color: "rgba(36, 58, 110, 0.85)",
+    heightOffset: 280,
+    amplitude: 32,
+    frequency: 0.0075,
+    speed: 0.085
+  },
+  {
+    color: "rgba(44, 72, 140, 0.9)",
+    heightOffset: 220,
+    amplitude: 36,
+    frequency: 0.009,
+    speed: 0.12
+  },
+  {
+    color: "rgba(58, 96, 168, 0.95)",
+    heightOffset: 170,
+    amplitude: 26,
+    frequency: 0.011,
+    speed: 0.16
+  }
+];
+const parallaxLightTrails = [
+  { color: "rgba(115, 173, 255, 0.28)", speed: 0.05, heightOffset: 320, thickness: 10 },
+  { color: "rgba(255, 183, 233, 0.32)", speed: 0.08, heightOffset: 280, thickness: 8 },
+  { color: "rgba(124, 243, 216, 0.25)", speed: 0.11, heightOffset: 240, thickness: 6 }
+];
 const markBackgroundReady = () => {
   backgroundReady = true;
   backgroundDimensions = {
@@ -3695,6 +3725,24 @@ function update(delta) {
     player.onGround = true;
   }
 
+  const atRightEdge = player.x + player.width >= viewport.width - 0.001;
+  const atLeftEdge = player.x <= 0.001;
+  let parallaxVelocity = player.vx;
+  if (atRightEdge && moveRight && !moveLeft) {
+    parallaxVelocity = maxSpeed;
+  } else if (atLeftEdge && moveLeft && !moveRight) {
+    parallaxVelocity = -maxSpeed;
+  }
+  parallaxScroll += parallaxVelocity * (delta / 16.666);
+  if (!Number.isFinite(parallaxScroll)) {
+    parallaxScroll = 0;
+  } else if (parallaxScroll > 10000 || parallaxScroll < -10000) {
+    parallaxScroll = wrapOffset(parallaxScroll, 10000);
+    if (parallaxScroll > 5000) {
+      parallaxScroll -= 10000;
+    }
+  }
+
   for (const platform of platforms) {
     const isAbovePlatform = previousY + player.height <= platform.y;
     const isWithinX =
@@ -4001,6 +4049,172 @@ function update(delta) {
   ui.setPrompt(promptText, promptTarget);
 }
 
+function wrapOffset(value, length) {
+  if (!Number.isFinite(length) || length === 0) {
+    return 0;
+  }
+  let remainder = value % length;
+  if (remainder < 0) {
+    remainder += length;
+  }
+  return remainder;
+}
+
+function createStarfield(count) {
+  const stars = [];
+  for (let index = 0; index < count; index += 1) {
+    stars.push({
+      x: Math.random(),
+      y: Math.random(),
+      size: 0.6 + Math.random() * 1.6,
+      parallax: 0.05 + Math.random() * 0.35,
+      alpha: 0.35 + Math.random() * 0.45,
+      twinkleOffset: Math.random() * Math.PI * 2
+    });
+  }
+  return stars;
+}
+
+function drawStarfield(ctx, time) {
+  ctx.save();
+  const starfieldHeight = Math.max(groundY - 140, viewport.height * 0.42);
+  for (const star of parallaxStarfield) {
+    const x = ((star.x * viewport.width - parallaxScroll * star.parallax) % viewport.width + viewport.width) %
+      viewport.width;
+    const y = Math.max(star.y * starfieldHeight, 4);
+    const twinkle = 0.55 + Math.sin(time * 1.6 + star.twinkleOffset) * 0.25;
+    ctx.globalAlpha = star.alpha * twinkle;
+    ctx.fillStyle = "#ffffff";
+    ctx.fillRect(x, y, star.size, star.size);
+  }
+  ctx.restore();
+}
+
+function drawParallaxBackgroundImage(ctx) {
+  if (!backgroundReady) {
+    return;
+  }
+
+  const { width: sourceWidth, height: sourceHeight } = backgroundDimensions;
+  if (!(sourceWidth > 0) || !(sourceHeight > 0)) {
+    return;
+  }
+
+  const widthScale = viewport.width / sourceWidth;
+  const heightScale = viewport.height / sourceHeight;
+  const scale = Math.min(widthScale, heightScale);
+  const drawWidth = sourceWidth * scale;
+  const drawHeight = sourceHeight * scale;
+  const offsetY = (viewport.height - drawHeight) / 2;
+
+  if (!(drawWidth > 0) || !(drawHeight > 0)) {
+    return;
+  }
+
+  const scrollOffset = wrapOffset(parallaxScroll * 0.4, drawWidth);
+  for (let x = -drawWidth; x <= viewport.width + drawWidth; x += drawWidth) {
+    const drawX = Math.round(x - scrollOffset);
+    ctx.drawImage(
+      backgroundImage,
+      0,
+      0,
+      sourceWidth,
+      sourceHeight,
+      drawX,
+      offsetY,
+      drawWidth,
+      drawHeight
+    );
+  }
+
+  const haze = ctx.createLinearGradient(0, 0, 0, viewport.height);
+  haze.addColorStop(0, "rgba(9, 15, 32, 0)");
+  haze.addColorStop(0.55, "rgba(9, 15, 32, 0.18)");
+  haze.addColorStop(1, "rgba(9, 15, 32, 0.55)");
+  ctx.fillStyle = haze;
+  ctx.fillRect(0, 0, viewport.width, viewport.height);
+}
+
+function drawParallaxRidges(ctx, time) {
+  for (const layer of parallaxRidgeLayers) {
+    const baseY = Math.max(groundY - layer.heightOffset, 48);
+    const tileWidth = Math.max(220, viewport.width / 3);
+    const offset = parallaxScroll * layer.speed;
+
+    ctx.beginPath();
+    ctx.moveTo(-tileWidth, viewport.height);
+    ctx.lineTo(-tileWidth, baseY);
+    for (let x = -tileWidth; x <= viewport.width + tileWidth; x += 12) {
+      const worldX = x + offset;
+      const wave = Math.sin(worldX * layer.frequency + time * (layer.speed * 2.6));
+      const crest = Math.cos(worldX * layer.frequency * 0.45 + time * 0.6);
+      const y = baseY + wave * layer.amplitude + crest * layer.amplitude * 0.24;
+      ctx.lineTo(x, y);
+    }
+    ctx.lineTo(viewport.width + tileWidth, viewport.height);
+    ctx.closePath();
+    ctx.fillStyle = layer.color;
+    ctx.fill();
+  }
+}
+
+function drawLightTrails(ctx, time) {
+  for (const trail of parallaxLightTrails) {
+    const y = Math.max(groundY - trail.heightOffset, 32);
+    const spacing = 260;
+    const offset = wrapOffset(parallaxScroll * trail.speed + time * 36 * trail.speed, spacing);
+    for (let x = -spacing; x <= viewport.width + spacing; x += spacing) {
+      const drawX = x - offset;
+      const gradient = ctx.createLinearGradient(drawX, y, drawX + spacing * 0.5, y + trail.thickness);
+      gradient.addColorStop(0, trail.color);
+      gradient.addColorStop(1, "rgba(12, 18, 32, 0)");
+      ctx.fillStyle = gradient;
+      ctx.fillRect(drawX, y, spacing, trail.thickness);
+    }
+  }
+
+  ctx.fillStyle = "rgba(255, 255, 255, 0.12)";
+  ctx.fillRect(0, groundY - 2, viewport.width, 3);
+}
+
+function drawGroundPlane(ctx) {
+  const groundHeight = viewport.height - groundY;
+  const baseGradient = ctx.createLinearGradient(0, groundY, 0, viewport.height);
+  baseGradient.addColorStop(0, "#16312a");
+  baseGradient.addColorStop(1, "#061612");
+  ctx.fillStyle = baseGradient;
+  ctx.fillRect(0, groundY, viewport.width, groundHeight);
+
+  const tileWidth = 76;
+  const offset = wrapOffset(parallaxScroll * 1.24, tileWidth);
+  for (let x = -tileWidth; x <= viewport.width + tileWidth; x += tileWidth) {
+    const drawX = x - offset;
+    const stripeGradient = ctx.createLinearGradient(drawX, groundY, drawX, groundY + groundHeight);
+    stripeGradient.addColorStop(0, "rgba(124, 243, 216, 0.18)");
+    stripeGradient.addColorStop(0.7, "rgba(30, 66, 52, 0.12)");
+    stripeGradient.addColorStop(1, "rgba(10, 24, 20, 0)");
+    ctx.fillStyle = stripeGradient;
+    ctx.fillRect(drawX, groundY, tileWidth, groundHeight);
+
+    const rimGradient = ctx.createLinearGradient(drawX, groundY - 6, drawX, groundY + 18);
+    rimGradient.addColorStop(0, "rgba(200, 255, 244, 0.35)");
+    rimGradient.addColorStop(1, "rgba(28, 64, 46, 0)");
+    ctx.fillStyle = rimGradient;
+    ctx.fillRect(drawX, groundY - 6, tileWidth, 24);
+  }
+}
+
+function renderParallaxBackdrop(ctx, time) {
+  ctx.fillStyle = getFallbackBackgroundGradient();
+  ctx.fillRect(0, 0, viewport.width, viewport.height);
+
+  drawStarfield(ctx, time);
+  drawParallaxBackgroundImage(ctx);
+  drawParallaxRidges(ctx, time);
+  drawGroundPlane(ctx);
+  drawLightTrails(ctx, time);
+}
+
 function render(timestamp) {
   const time = timestamp / 1000;
 
@@ -4013,40 +4227,7 @@ function render(timestamp) {
     0
   );
 
-  ctx.fillStyle = getFallbackBackgroundGradient();
-  ctx.fillRect(0, 0, viewport.width, viewport.height);
-
-  if (backgroundReady) {
-    const { width: sourceWidth, height: sourceHeight } = backgroundDimensions;
-    if (sourceWidth > 0 && sourceHeight > 0) {
-      const widthScale = viewport.width / sourceWidth;
-      const heightScale = viewport.height / sourceHeight;
-      const scale = Math.min(widthScale, heightScale);
-      const drawWidth = sourceWidth * scale;
-      const drawHeight = sourceHeight * scale;
-      const offsetX = (viewport.width - drawWidth) / 2;
-      const offsetY = (viewport.height - drawHeight) / 2;
-      ctx.drawImage(
-        backgroundImage,
-        0,
-        0,
-        sourceWidth,
-        sourceHeight,
-        offsetX,
-        offsetY,
-        drawWidth,
-        drawHeight
-      );
-    } else {
-      ctx.drawImage(backgroundImage, 0, 0, viewport.width, viewport.height);
-    }
-  }
-
-  ctx.fillStyle = "#1c2b33";
-  ctx.fillRect(0, groundY, viewport.width, viewport.height - groundY);
-
-  ctx.fillStyle = "#243b25";
-  ctx.fillRect(0, groundY, viewport.width, 16);
+  renderParallaxBackdrop(ctx, time);
 
   if (platformSprite.isReady() && platformSprite.image) {
     ctx.save();


### PR DESCRIPTION
## Summary
- replace the static backdrop render with a reusable parallax renderer that loops the image and adds atmospheric layers
- drive the scrolling offset from player movement so the sky, mountains, and ground slide endlessly in either direction
- refresh the ground plane styling with repeating energy trails to reinforce the new motion

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68da351ce9ac8324a88156970e23298c