### PR TITLE
Stop parallax background from following player movement

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1287,6 +1287,7 @@ const parallaxLayers = parallaxLayerSources.map((layer) => {
   }
   return layerState;
 });
+const PARALLAX_IDLE_SCROLL_SPEED = 0.85;
 let parallaxScroll = 0;
 let cameraScrollX = 0;
 
@@ -3778,7 +3779,7 @@ function update(delta) {
     player.onGround = true;
   }
 
-  parallaxScroll += player.vx * (delta / 16.666);
+  parallaxScroll += PARALLAX_IDLE_SCROLL_SPEED * (delta / 16.666);
   if (!Number.isFinite(parallaxScroll)) {
     parallaxScroll = 0;
   } else if (parallaxScroll > 10000 || parallaxScroll < -10000) {


### PR DESCRIPTION
## Summary
- add a constant scroll speed for the parallax backdrop
- remove the dependency on the player's velocity so background assets stay put when the player moves

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dad3ca8d748324bc6fb13ba1eccaee