### PR TITLE
Stop idle parallax background scroll

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1269,7 +1269,10 @@ const parallaxLayers = parallaxLayerSources.map((layer) => {
   }
   return layerState;
 });
-const PARALLAX_IDLE_SCROLL_SPEED = 0.85;
+// The lobby previously applied a subtle idle scroll to the parallax background to
+// keep the scene feeling lively. Disable that behaviour so the background stays
+// perfectly still unless future updates explicitly change parallaxScroll.
+const PARALLAX_IDLE_SCROLL_SPEED = 0;
 let parallaxScroll = 0;
 let cameraScrollX = 0;
 


### PR DESCRIPTION
## Summary
- disable the idle parallax scroll speed so the lobby background stays stationary

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dada7b3f988324b7dc3d579dc05772