### PR TITLE
feat: enable lobby layout customization

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -312,6 +312,86 @@ body.is-scroll-locked {
   background: #0c0f18;
 }
 
+.game-canvas.is-customizing {
+  cursor: grab;
+}
+
+.game-canvas.is-customizing.is-dragging {
+  cursor: grabbing;
+}
+
+.layout-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 0 4px;
+}
+
+.layout-controls__toggle {
+  border: none;
+  border-radius: 16px;
+  padding: 10px 20px;
+  font-weight: 600;
+  font-size: 0.95rem;
+  background: linear-gradient(135deg, #7fd7ff, #ff8ed1);
+  color: #241c4f;
+  box-shadow:
+    0 12px 24px rgba(26, 16, 66, 0.3),
+    0 4px 0 rgba(47, 71, 255, 0.28);
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.layout-controls__toggle:hover {
+  transform: translateY(-1px);
+  box-shadow:
+    0 14px 28px rgba(26, 16, 66, 0.32),
+    0 6px 0 rgba(47, 71, 255, 0.32);
+}
+
+.layout-controls__toggle:focus-visible {
+  outline: 3px solid #2f47ff;
+  outline-offset: 3px;
+}
+
+.layout-controls__toggle.is-active {
+  background: linear-gradient(135deg, #ffbb5c, #ff6ec7);
+  box-shadow:
+    0 14px 28px rgba(75, 32, 96, 0.35),
+    0 0 0 3px rgba(255, 255, 255, 0.55);
+}
+
+.layout-controls__hint {
+  flex: 1 1 240px;
+  margin: 0;
+  font-size: 0.9rem;
+  color: rgba(255, 255, 255, 0.82);
+  background: linear-gradient(135deg, rgba(47, 71, 255, 0.18), rgba(255, 110, 199, 0.18));
+  padding: 10px 16px;
+  border-radius: 14px;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.25);
+}
+
+.canvas-customization-overlay {
+  position: absolute;
+  top: 18px;
+  left: 18px;
+  max-width: calc(100% - 36px);
+  padding: 12px 18px;
+  border-radius: 14px;
+  background: rgba(24, 26, 52, 0.82);
+  color: #fefbff;
+  font-size: 0.95rem;
+  line-height: 1.35;
+  box-shadow:
+    0 12px 28px rgba(14, 16, 32, 0.45),
+    inset 0 0 0 1px rgba(255, 255, 255, 0.18);
+  pointer-events: none;
+  z-index: 6;
+}
+
 .chat-board {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- add layout persistence helpers and identifiers for lobby interactables
- introduce a customization toggle, drag handling, and visual outlines for repositioning lobby objects
- style the new layout controls and customization overlay messaging

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dad6d1e82883249e82d27c3a2ba269