### PR TITLE
Fix idle parallax drift when lobby background is static

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -3796,13 +3796,17 @@ function update(delta) {
     player.onGround = true;
   }
 
-  parallaxScroll += PARALLAX_IDLE_SCROLL_SPEED * (delta / 16.666);
-  if (!Number.isFinite(parallaxScroll)) {
+  if (PARALLAX_IDLE_SCROLL_SPEED === 0) {
     parallaxScroll = 0;
-  } else if (parallaxScroll > 10000 || parallaxScroll < -10000) {
-    parallaxScroll = wrapOffset(parallaxScroll, 10000);
-    if (parallaxScroll > 5000) {
-      parallaxScroll -= 10000;
+  } else {
+    parallaxScroll += PARALLAX_IDLE_SCROLL_SPEED * (delta / 16.666);
+    if (!Number.isFinite(parallaxScroll)) {
+      parallaxScroll = 0;
+    } else if (parallaxScroll > 10000 || parallaxScroll < -10000) {
+      parallaxScroll = wrapOffset(parallaxScroll, 10000);
+      if (parallaxScroll > 5000) {
+        parallaxScroll -= 10000;
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- guard the parallax update loop so the scroll offset is reset to zero whenever idle scrolling is disabled
- ensure the lobby background image stays perfectly still by preventing residual scroll values when PARALLAX_IDLE_SCROLL_SPEED is zero

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dadc0d8690832494c0ca96110e5058