### PR TITLE
Add lobby layout editor for draggable interactables

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -304,6 +304,15 @@ body.is-scroll-locked {
   align-items: center;
 }
 
+.canvas-surface.is-editing {
+  cursor: grab;
+  touch-action: none;
+}
+
+.canvas-surface.is-editing.is-dragging {
+  cursor: grabbing;
+}
+
 .game-canvas {
   width: 100%;
   height: auto;
@@ -419,6 +428,29 @@ body.is-scroll-locked {
     0 6px 0 rgba(47, 71, 255, 0.55),
     0 14px 26px rgba(38, 19, 72, 0.35);
   background: linear-gradient(145deg, #ffe07a 0%, #ff7fcc 60%, #6f92ff 100%);
+}
+
+.layout-editor__hint {
+  position: absolute;
+  bottom: 18px;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 10px 18px;
+  border-radius: 18px;
+  background: rgba(14, 22, 52, 0.88);
+  color: #f4f6ff;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  z-index: 16;
+}
+
+.layout-editor__hint.is-visible {
+  opacity: 1;
 }
 
 @media (hover: hover) and (pointer: fine) {
@@ -803,6 +835,15 @@ body.is-scroll-locked {
   transform: translateY(-2px);
   box-shadow: 0 18px 32px rgba(10, 18, 46, 0.35);
   background: linear-gradient(135deg, rgba(74, 108, 208, 0.8), rgba(36, 58, 140, 0.76));
+}
+
+.hud-panel__button--active {
+  background: linear-gradient(135deg, rgba(126, 88, 224, 0.92), rgba(58, 38, 160, 0.88));
+  box-shadow: 0 20px 36px rgba(12, 18, 52, 0.45);
+}
+
+.hud-panel__button--active:hover {
+  background: linear-gradient(135deg, rgba(146, 108, 236, 0.96), rgba(68, 46, 176, 0.92));
 }
 
 .hud-panel__button:focus-visible {


### PR DESCRIPTION
## Summary
- persist interactable and portal positions with local storage so saved layouts can be restored
- add a lobby layout editor that lets players drag assets, lock the layout, and reset to defaults
- expose customize/reset controls in the HUD and style the editing state overlay

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dadcc209448324bfad31f9d1fef918