### PR TITLE
Ensure full-page lobby background support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ Open the printed local URL in your browser to explore the lobby during developme
 
 Add a `webpagebackground.png` file to the `public/` directory to replace the default gradient backdrop that surrounds the lobby canvas. The image is applied automatically when present and falls back to the gradient when removed.
 
+```
+public/
+└── webpagebackground.png  ← place your full-page background here
+```
+
+The background stretches to cover the entire viewport, so large landscape images work best.
+
 ## Custom toolbar branding
 
 To replace the Astrocat Lobby wordmark in the navigation toolbar, add a `toolbar-brand.png` image to either the `public/` directory or the embedded mini game folder at `public/AstroCats3/`. The lobby prefers the root image when both exist and gracefully falls back to text when no custom graphic is supplied.

--- a/src/style.css
+++ b/src/style.css
@@ -18,7 +18,8 @@ body {
   font-family: inherit;
   background-image: var(--page-background-overlay), var(--page-background-base);
   background-repeat: no-repeat, no-repeat;
-  background-size: cover, auto;
+  /* The gradient fallback is stretched to fill the viewport so the scene always covers the page. */
+  background-size: cover, cover;
   background-position: center, center;
   background-attachment: fixed, fixed;
   background-color: #7dbbff;


### PR DESCRIPTION
## Summary
- stretch the lobby's fallback gradient so the background always covers the full viewport
- document where to place a custom `webpagebackground.png` asset for the page backdrop

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68daef2d42e4832490b41f90d3f438be