### PR TITLE
Handle custom background HEAD failures gracefully

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -433,10 +433,10 @@ function shouldUseCustomPageBackground() {
   })
     .then((response) => {
       if (!response) {
-        return false;
+        return true;
       }
 
-      if (response.ok) {
+      if (response?.ok) {
         const contentType = response.headers.get("content-type");
         if (!contentType) {
           return true;
@@ -455,7 +455,16 @@ function shouldUseCustomPageBackground() {
 
       return false;
     })
-    .catch(() => false);
+    .catch((error) => {
+      if (typeof console !== "undefined" && error) {
+        console.warn(
+          "Falling back to loading custom page background after HEAD probe failed.",
+          error
+        );
+      }
+
+      return true;
+    });
 
   return customBackgroundAvailabilityProbe;
 }


### PR DESCRIPTION
## Summary
- allow the custom background availability probe to fall back to loading when the HEAD request fails
- log HEAD probe failures so they can be diagnosed while still allowing the image to load

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68daf2a3d9108324b3ad057b07d3a39a