### PR TITLE
Add fallback sizing for HUD modals to prevent overflow

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -831,6 +831,9 @@ body.is-scroll-locked {
 }
 
 .hud-modal {
+  width: calc(100% - 48px);
+  max-width: 920px;
+  max-height: 92vh;
   width: min(920px, calc(100% - 48px));
   max-width: min(100%, calc(100% - 48px));
   max-height: min(92vh, 860px);
@@ -1059,6 +1062,9 @@ body.is-scroll-locked {
   .hud-modal {
     padding: 24px;
     border-radius: 20px;
+    width: calc(100% - 32px);
+    max-width: 100%;
+    max-height: 92vh;
     width: min(100%, calc(100% - 32px));
     max-width: min(100%, calc(100% - 32px));
     max-height: min(92vh, 760px);


### PR DESCRIPTION
## Summary
- add explicit width and height fallbacks for HUD modals so browsers without CSS `min()` support keep dialogs within the viewport
- mirror the fallback sizing inside the mobile breakpoint to maintain responsive behavior

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da307df77c8324a2b34361e94160a1