### PR TITLE
Fix public asset fallback resolution

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -307,6 +307,11 @@ function resolvePublicAssetUrl(relativePath) {
     return merged;
   }
 
+  const resolvedFromDocument = resolveUsingDocumentBase(candidate);
+  if (resolvedFromDocument) {
+    return resolvedFromDocument;
+  }
+
   return `/${candidate}`;
 }
 


### PR DESCRIPTION
## Summary
- ensure resolvePublicAssetUrl falls back to the document base when the Vite base URL is unavailable
- allow custom background images to load when opening the app without the generated public manifest

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68daf7f989588324bc28198983d22fc6