### PR TITLE
Simplify mini game loadout layout

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -1405,6 +1405,8 @@ body.is-scroll-locked {
   flex-direction: column;
   gap: 16px;
   width: 100%;
+  max-width: 440px;
+  margin: 0 auto;
   padding: 18px 20px;
   border-radius: 20px;
   background: rgba(255, 255, 255, 0.06);
@@ -1435,10 +1437,9 @@ body.is-scroll-locked {
 }
 
 .loadout-panel__form {
-  display: grid;
+  display: flex;
+  flex-direction: column;
   gap: 12px;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  align-items: start;
 }
 
 .loadout-panel__field {
@@ -1448,15 +1449,14 @@ body.is-scroll-locked {
 }
 
 .loadout-preview {
-  display: grid;
+  display: flex;
+  flex-direction: column;
   gap: 12px;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  align-items: stretch;
 }
 
 .loadout-preview__item {
-  display: grid;
-  grid-template-rows: auto minmax(0, 1fr) auto auto auto;
+  display: flex;
+  flex-direction: column;
   gap: 10px;
   padding: 14px;
   border-radius: 18px;
@@ -1464,7 +1464,6 @@ body.is-scroll-locked {
   border: 1px solid rgba(134, 225, 255, 0.18);
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
-  height: 100%;
 }
 
 .loadout-preview__item:hover {


### PR DESCRIPTION
## Summary
- simplify the mini game loadout panel by using a single column layout
- constrain the panel width so the popup contents no longer overlap

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68daf899495083249e19db1f9af92884