### PR TITLE
Fix asset resolution for file protocol

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -286,6 +286,17 @@ function resolvePublicAssetUrl(relativePath) {
     return candidate;
   }
 
+  if (typeof window !== "undefined" && window.location?.protocol === "file:") {
+    const resolvedFromDocument = resolveUsingDocumentBase(candidate);
+    if (resolvedFromDocument) {
+      return resolvedFromDocument;
+    }
+
+    return candidate.startsWith("./") || candidate.startsWith("../")
+      ? candidate
+      : `./${candidate}`;
+  }
+
   const base = import.meta?.env?.BASE_URL ?? "/";
 
   if (typeof base === "string" && base) {
@@ -310,6 +321,12 @@ function resolvePublicAssetUrl(relativePath) {
   const resolvedFromDocument = resolveUsingDocumentBase(candidate);
   if (resolvedFromDocument) {
     return resolvedFromDocument;
+  }
+
+  if (typeof window !== "undefined" && window.location?.protocol === "file:") {
+    return candidate.startsWith("./") || candidate.startsWith("../")
+      ? candidate
+      : `./${candidate}`;
   }
 
   return `/${candidate}`;


### PR DESCRIPTION
## Summary
- update public asset resolution to use document base when running from the file:// protocol
- ensure file-served builds fall back to relative URLs so toolbar and background assets load correctly

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dafd4399e48324bfa25ec806049fa8