### PR TITLE
Fix public asset URLs when served from subpaths

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -323,13 +323,25 @@ function resolvePublicAssetUrl(relativePath) {
     return resolvedFromDocument;
   }
 
-  if (typeof window !== "undefined" && window.location?.protocol === "file:") {
-    return candidate.startsWith("./") || candidate.startsWith("../")
-      ? candidate
-      : `./${candidate}`;
+  if (typeof window !== "undefined" && window.location) {
+    const { location } = window;
+
+    if (location.protocol === "file:") {
+      return candidate.startsWith("./") || candidate.startsWith("../")
+        ? candidate
+        : `./${candidate}`;
+    }
+
+    if (typeof location.pathname === "string") {
+      const directoryPath = normalisePathnameForDirectory(location.pathname);
+      if (directoryPath && directoryPath !== "/") {
+        const trimmedCandidate = candidate.replace(/^\/+/, "");
+        return `${directoryPath}${trimmedCandidate}`;
+      }
+    }
   }
 
-  return `/${candidate}`;
+  return candidate.startsWith("/") ? candidate : `/${candidate}`;
 }
 
 function tryCreateAssetManifest() {


### PR DESCRIPTION
## Summary
- update the public asset URL resolver to honour the current location when manifest lookups fail
- ensure custom backgrounds and toolbar artwork load when the site is hosted from a subdirectory

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db06cee8b483249db309fc6d86e687