### PR TITLE
Fix page background fallback to gradient

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -906,7 +906,7 @@ function applyCustomPageBackground() {
     }
 
     const applyFallbackBackground = () => {
-      applyPageBackgroundFromUrl(body, backgroundImageUrl);
+      applyPageBackgroundFromUrl(body, null);
     };
 
     applyFallbackBackground();


### PR DESCRIPTION
## Summary
- ensure the full-page background falls back to the gradient instead of the gameplay art when no override is provided

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db2594e1d48324ba0d1961b31e4fd2