### PR TITLE
Make leaderboard API optional during local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,13 @@ To replace the Astrocat Lobby wordmark in the navigation toolbar, add a `toolbar
 
 The cabinet now looks for `/public/AstroCats3/index.html` inside an iframe, falling back to `/AstroCats3/index.html` when needed, so ensure all asset paths remain relative to those files. You can also open the mini game directly in a new browser tab at `/public/AstroCats3/index.html` (or `/AstroCats3/index.html` if you rely on the legacy location) to verify it deploys correctly.
 
+### Configuring the mini game leaderboard
+
+The bundled AstroCats3 build no longer assumes a hosted leaderboard API when you run the lobby locally. This prevents console
+errors from failed network requests during development. To point the mini game at your own deployment, edit the helper at
+`public/leaderboard-config.js` and set `configuredBaseUrl` to the base URL that serves the leaderboard endpoints. The script runs
+before the mini game boots and keeps the existing dataset/global overrides in place if you already provide them elsewhere.
+
 ### Updating the bundled mini game script
 
 For broader browser compatibility the production build ships a transpiled version of the mini game script at

--- a/public/AstroCats3/README.md
+++ b/public/AstroCats3/README.md
@@ -158,11 +158,12 @@ platform’s routing API.
 ### Configuring the client
 
 Expose the leaderboard base URL to the browser by setting the global
-`window.NYAN_ESCAPE_API_BASE_URL` before `index.html` loads, or by adding a
-`data-nyan-api-base` attribute to `<html>`/`<body>`. When the API is reachable
-the overlay displays the latest standings; if the network call fails the game
-falls back to a cached snapshot stored in `localStorage` and surfaces an offline
-warning in the HUD.
+`window.NYAN_ESCAPE_API_BASE_URL` before `index.html` loads, by adding a
+`data-nyan-api-base` attribute to `<html>`/`<body>`, or by editing the
+`public/leaderboard-config.js` helper bundled with the lobby. When the API is
+reachable the overlay displays the latest standings; if the network call fails
+the game falls back to a cached snapshot stored in `localStorage` and surfaces
+an offline warning in the HUD.
 
 Each submission now sends a deterministic `deviceId`, player name, score, streak
 information, timestamps, and a run token issued before launch. The UI reports

--- a/public/AstroCats3/index.html
+++ b/public/AstroCats3/index.html
@@ -785,9 +785,7 @@
             <p class="mascot-text" data-mascot-text></p>
         </div>
     </div>
-    <script>
-        window.NYAN_ESCAPE_API_BASE_URL = "https://api.xpal.fun";
-    </script>
+    <script src="../leaderboard-config.js"></script>
     <script type="module" src="scripts/app.js?v=20240911"></script>
 
 </body>

--- a/public/leaderboard-config.js
+++ b/public/leaderboard-config.js
@@ -1,0 +1,29 @@
+/**
+ * Configure the AstroCats leaderboard API endpoint.
+ *
+ * By default the mini game runs without a remote leaderboard to avoid
+ * development errors when the production API is unavailable. Supply the base
+ * URL for your deployment by editing the `configuredBaseUrl` value below or by
+ * replacing this helper with your own loader.
+ */
+(function configureLeaderboardApiBase() {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  /**
+   * Set this to the base URL that hosts the leaderboard API. Example:
+   *   const configuredBaseUrl = "https://your-domain.example.com";
+   */
+  var configuredBaseUrl = "";
+
+  if (typeof configuredBaseUrl === "string") {
+    configuredBaseUrl = configuredBaseUrl.trim();
+  }
+
+  if (!configuredBaseUrl) {
+    return;
+  }
+
+  window.NYAN_ESCAPE_API_BASE_URL = configuredBaseUrl;
+})();


### PR DESCRIPTION
## Summary
- add a configurable leaderboard bootstrap script that defaults to no remote API
- load the helper from the embedded AstroCats3 index.html to avoid failed requests
- document how to point the mini game at a custom leaderboard endpoint

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db2db7fd4c8324bb57a821007ce07e