### PR TITLE
Fix onboarding inputs overflowing

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -2554,6 +2554,7 @@ body.is-scroll-locked {
   color: #f6f7ff;
   font-size: 15px;
   box-shadow: inset 0 0 0 1px rgba(10, 16, 34, 0.4);
+  box-sizing: border-box;
 }
 
 .onboarding-input:focus {


### PR DESCRIPTION
## Summary
- ensure onboarding form inputs use border-box sizing so they stay within the modal container

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db2e93018483249d5db6760cb38083