### PR TITLE
Add onboarding starter selection carousel

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -2606,6 +2606,228 @@ body.is-scroll-locked {
   min-width: 0;
 }
 
+.onboarding-field--starter,
+.onboarding-field--stats {
+  gap: 12px;
+}
+
+.starter-carousel {
+  position: relative;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 12px;
+}
+
+.starter-carousel__viewport {
+  overflow: hidden;
+  border-radius: 20px;
+  box-shadow: 0 14px 34px rgba(12, 14, 32, 0.55);
+}
+
+.starter-carousel__track {
+  display: flex;
+  transition: transform 320ms ease;
+}
+
+.starter-carousel__slide {
+  flex: 0 0 100%;
+  display: flex;
+  justify-content: center;
+  padding: 12px;
+  box-sizing: border-box;
+}
+
+.starter-carousel__image {
+  width: min(100%, 220px);
+  aspect-ratio: 1;
+  border-radius: 20px;
+  object-fit: cover;
+  border: 2px solid rgba(140, 170, 255, 0.4);
+  background: rgba(20, 25, 44, 0.75);
+  box-shadow:
+    0 18px 32px rgba(10, 12, 32, 0.6),
+    inset 0 2px 8px rgba(255, 255, 255, 0.12);
+}
+
+.starter-carousel__control {
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  border: 1px solid rgba(135, 180, 255, 0.5);
+  background: rgba(22, 30, 56, 0.95);
+  color: #f6f7ff;
+  font-size: 22px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background 180ms ease, transform 180ms ease, box-shadow 180ms ease;
+}
+
+.starter-carousel__control:disabled {
+  opacity: 0.35;
+  cursor: default;
+}
+
+.starter-carousel__control:not(:disabled):hover,
+.starter-carousel__control:not(:disabled):focus-visible {
+  outline: none;
+  background: rgba(96, 128, 255, 0.9);
+  transform: translateY(-2px);
+  box-shadow: 0 12px 20px rgba(32, 42, 92, 0.45);
+}
+
+.starter-carousel__indicators {
+  grid-column: 1 / -1;
+  display: flex;
+  justify-content: center;
+  gap: 6px;
+  margin-top: 8px;
+}
+
+.starter-carousel__indicator {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  border: none;
+  background: rgba(140, 160, 220, 0.4);
+  cursor: pointer;
+  transition: background 180ms ease, transform 180ms ease;
+}
+
+.starter-carousel__indicator.is-active {
+  background: rgba(124, 243, 216, 0.85);
+  transform: scale(1.2);
+}
+
+.starter-carousel__info {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  color: #f6f7ff;
+}
+
+.starter-carousel__name {
+  margin: 0;
+  font-size: 20px;
+  font-weight: 600;
+  color: #f6f7ff;
+}
+
+.starter-carousel__tagline {
+  margin: 0;
+  font-size: 14px;
+  color: rgba(124, 243, 216, 0.9);
+}
+
+.starter-carousel__description {
+  margin: 0;
+  font-size: 13px;
+  color: rgba(178, 191, 240, 0.8);
+}
+
+.stat-allocation__header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.stat-allocation__points {
+  font-size: 12px;
+  font-weight: 600;
+  padding: 4px 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(124, 243, 216, 0.4);
+  background: rgba(124, 243, 216, 0.18);
+  color: #7cf3d8;
+}
+
+.stat-allocation__list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.stat-allocation__item {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 16px;
+  border-radius: 16px;
+  background: rgba(18, 24, 48, 0.7);
+  box-shadow: inset 0 0 0 1px rgba(100, 130, 210, 0.25);
+}
+
+.stat-allocation__meta {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.stat-allocation__label {
+  font-size: 15px;
+  font-weight: 600;
+  color: #f6f7ff;
+}
+
+.stat-allocation__hint {
+  margin: 0;
+  font-size: 12px;
+  color: rgba(178, 191, 240, 0.72);
+}
+
+.stat-allocation__controls {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.stat-allocation__button {
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  border: 1px solid rgba(120, 150, 255, 0.4);
+  background: rgba(20, 28, 56, 0.92);
+  color: #f6f7ff;
+  font-size: 18px;
+  cursor: pointer;
+  transition: background 180ms ease, transform 180ms ease, box-shadow 180ms ease;
+}
+
+.stat-allocation__button:disabled {
+  opacity: 0.35;
+  cursor: default;
+}
+
+.stat-allocation__button:not(:disabled):hover,
+.stat-allocation__button:not(:disabled):focus-visible {
+  outline: none;
+  background: rgba(96, 128, 255, 0.9);
+  transform: translateY(-1px);
+  box-shadow: 0 8px 18px rgba(36, 44, 96, 0.45);
+}
+
+.stat-allocation__value {
+  min-width: 36px;
+  text-align: center;
+  font-size: 16px;
+  font-weight: 600;
+  color: #f6f7ff;
+}
+
+.stat-allocation__error {
+  margin: 0;
+  font-size: 12px;
+  color: #ffb4c8;
+  background: rgba(255, 180, 200, 0.16);
+  border: 1px solid rgba(255, 180, 200, 0.35);
+  padding: 8px 12px;
+  border-radius: 12px;
+}
+
 @media (max-width: 960px) {
   .onboarding-modal {
     padding: 28px;
@@ -2626,6 +2848,20 @@ body.is-scroll-locked {
 
   .onboarding-field--wide {
     grid-column: auto;
+  }
+
+  .starter-carousel {
+    grid-template-columns: 1fr;
+    justify-items: center;
+    gap: 16px;
+  }
+
+  .starter-carousel__control {
+    grid-column: 1 / -1;
+  }
+
+  .starter-carousel__viewport {
+    width: 100%;
   }
 }
 


### PR DESCRIPTION
## Summary
- add multiple starter definitions and helper utilities for validating starter choices and attributes
- extend the onboarding flow with a starter selection carousel and stat allocation controls
- persist chosen attributes in account data and refresh styles for the new onboarding UI

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db2fa09e548324978ba21b39440842