### PR TITLE
Prevent Starcade launch during account onboarding

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -4821,9 +4821,18 @@ const isInteractiveElement = (target) => {
 };
 
 window.addEventListener("keydown", (event) => {
-  if (movementKeyCodes.has(event.code) && !isInteractiveElement(event.target)) {
+  if (onboardingInstance) {
+    return;
+  }
+
+  const interactive = isInteractiveElement(event.target);
+  if (movementKeyCodes.has(event.code) && !interactive) {
     event.preventDefault();
   }
+  if (interactive) {
+    return;
+  }
+
   audio.handleUserGesture();
   pressVirtualKey(event.code);
 });


### PR DESCRIPTION
## Summary
- stop routing lobby keyboard shortcuts when the onboarding overlay is active
- ensure interactive form fields no longer trigger lobby interactions while typing

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db357aa5f483248475cbb2d57a2425