### PR TITLE
Allow custom background to use more image formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ Open the printed local URL in your browser to explore the lobby during developme
 
 ## Custom page background
 
-Add a `webpagebackground.png` file to the `public/` directory to replace the default gradient backdrop that surrounds the lobby canvas. The image is applied automatically when present and falls back to the gradient when removed.
+Add a `webpagebackground` image (PNG, JPG/JPEG, WebP, AVIF, or GIF) to the `public/` directory to replace the default gradient backdrop that surrounds the lobby canvas. The image is applied automatically when present and falls back to the gradient when removed.
 
 ```
 public/
-└── webpagebackground.png  ← place your full-page background here
+└── webpagebackground.png  ← place your full-page background here (any of the supported extensions work)
 ```
 
 The background stretches to cover the entire viewport, so large landscape images work best.

--- a/src/main.js
+++ b/src/main.js
@@ -539,7 +539,14 @@ const baseCanvasHeight = 540;
 
 const customPageBackgroundSources = resolvePublicAssetCandidatesByBasename(
   "webpagebackground",
-  ["webpagebackground.png"]
+  [
+    "webpagebackground.png",
+    "webpagebackground.jpg",
+    "webpagebackground.jpeg",
+    "webpagebackground.webp",
+    "webpagebackground.avif",
+    "webpagebackground.gif"
+  ]
 );
 let customPageBackgroundUrl =
   customPageBackgroundSources.length > 0 ? customPageBackgroundSources[0] : null;

--- a/src/style.css
+++ b/src/style.css
@@ -5,7 +5,7 @@
   font-family: "Baloo 2", "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
   /* The gradient fallback shown whenever no custom background image is present. */
   --page-background-base: linear-gradient(180deg, #7dbbff 0%, #ffe7ff 68%, #fff6d1 100%);
-  /* Populated at runtime when public/webpagebackground.png is available. */
+  /* Populated at runtime when a custom public/webpagebackground.* image is available. */
   --page-background-overlay: none;
 }
 


### PR DESCRIPTION
## Summary
- allow the lobby page background loader to recognise additional common image extensions
- document the supported formats for the custom background variable and README instructions

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db36d5c6c08324a02aab4f3f99fea8