### PR TITLE
Fix combo decay window recursion

### DIFF
--- a/public/AstroCats3/scripts/app.js
+++ b/public/AstroCats3/scripts/app.js
@@ -14922,7 +14922,14 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     }
     function getComboDecayWindow() {
-        const baseWindow = getComboDecayWindow();
+        var _a, _b;
+        const configuredWindow = Number((_a = config === null || config === void 0 ? void 0 : config.comboDecayWindow) !== null && _a !== void 0 ? _a : NaN);
+        const fallbackWindow = Number((_b = baseGameConfig === null || baseGameConfig === void 0 ? void 0 : baseGameConfig.comboDecayWindow) !== null && _b !== void 0 ? _b : NaN);
+        const baseWindow = Number.isFinite(configuredWindow)
+            ? configuredWindow
+            : Number.isFinite(fallbackWindow)
+                ? fallbackWindow
+                : 5200;
         return Math.max(1000, Math.round(baseWindow * progressionEffects.comboWindowMultiplier));
     }
     function resetStreak() {

--- a/public/AstroCats3/scripts/app.source.js
+++ b/public/AstroCats3/scripts/app.source.js
@@ -16005,7 +16005,13 @@ const MAX_LOADOUT_NAME_LENGTH = 32;
     }
 
     function getComboDecayWindow() {
-        const baseWindow = getComboDecayWindow();
+        const configuredWindow = Number(config?.comboDecayWindow);
+        const fallbackWindow = Number(baseGameConfig?.comboDecayWindow);
+        const baseWindow = Number.isFinite(configuredWindow)
+            ? configuredWindow
+            : Number.isFinite(fallbackWindow)
+                ? fallbackWindow
+                : 5200;
         return Math.max(1000, Math.round(baseWindow * progressionEffects.comboWindowMultiplier));
     }
 


### PR DESCRIPTION
## Summary
- prevent `getComboDecayWindow` from recursively calling itself by reading configured values
- fall back to base game configuration when no override is provided

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68db38609bd48324b0f239e461ebc9e4