### PR TITLE
Center carousel images in starter selector

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -2640,11 +2640,14 @@ body.is-scroll-locked {
   flex: 0 0 100%;
   display: flex;
   justify-content: center;
+  align-items: center;
   padding: 12px;
   box-sizing: border-box;
 }
 
 .starter-carousel__image {
+  display: block;
+  margin: 0 auto;
   width: min(100%, 220px);
   aspect-ratio: 1;
   border-radius: 20px;


### PR DESCRIPTION
## Summary
- ensure carousel slides center their contents vertically
- center starter carousel images within each slide

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68db3aa87d90832499c24a3e5da92744