### PR TITLE
Fix mascot avatar cropping

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -565,7 +565,8 @@ body.is-scroll-locked {
 .chat-board__mascot-image {
   width: 100%;
   height: 100%;
-  object-fit: contain;
+  object-fit: cover;
+  object-position: center;
   display: block;
 }
 


### PR DESCRIPTION
## Summary
- ensure chat mascot avatars use cover positioning so the full character fills the frame again

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db3d64092083249393719464a5f13b