### PR TITLE
Improve onboarding flow for new players

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -2390,6 +2390,46 @@ body.is-scroll-locked {
   line-height: 1.5;
 }
 
+.onboarding-steps {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: clamp(12px, 2vh, 16px);
+}
+
+.onboarding-steps__item {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 14px 16px;
+  border-radius: 16px;
+  background: rgba(18, 26, 48, 0.88);
+  border: 1px solid rgba(134, 225, 255, 0.16);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+.onboarding-steps__badge {
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(197, 217, 255, 0.7);
+}
+
+.onboarding-steps__title {
+  font-size: 16px;
+  font-weight: 600;
+  color: rgba(230, 238, 255, 0.94);
+}
+
+.onboarding-steps__detail {
+  margin: 0;
+  font-size: 13px;
+  color: rgba(197, 217, 255, 0.78);
+  line-height: 1.4;
+}
+
 .onboarding-signin {
   margin: 0;
   padding: clamp(16px, 3vh, 18px) clamp(18px, 3vw, 20px);
@@ -2548,6 +2588,69 @@ body.is-scroll-locked {
   text-transform: uppercase;
   width: fit-content;
   box-shadow: inset 0 0 0 1px rgba(40, 66, 72, 0.45);
+  white-space: nowrap;
+}
+
+.onboarding-call-sign__display {
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+}
+
+.onboarding-call-sign__copy {
+  padding: 8px 14px;
+  border-radius: 12px;
+  border: 1px solid rgba(124, 243, 216, 0.45);
+  background: rgba(124, 243, 216, 0.15);
+  color: #7cf3d8;
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: transform 160ms ease, box-shadow 160ms ease, background 160ms ease;
+}
+
+.onboarding-call-sign__copy:hover,
+.onboarding-call-sign__copy:focus-visible {
+  outline: none;
+  transform: translateY(-2px);
+  background: rgba(124, 243, 216, 0.28);
+  box-shadow: 0 12px 20px rgba(12, 32, 28, 0.35);
+}
+
+.onboarding-call-sign__copy:disabled {
+  opacity: 0.55;
+  cursor: default;
+  transform: none;
+  box-shadow: none;
+}
+
+.onboarding-call-sign__note {
+  margin: 0;
+  font-size: 13px;
+  color: rgba(197, 217, 255, 0.78);
+}
+
+.onboarding-call-sign__actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+}
+
+.onboarding-call-sign__feedback {
+  font-size: 12px;
+  color: rgba(197, 217, 255, 0.78);
+}
+
+.onboarding-call-sign__feedback.is-success {
+  color: #7cf3d8;
+}
+
+.onboarding-call-sign__feedback.is-error {
+  color: #ff9aa2;
 }
 
 .onboarding-input {


### PR DESCRIPTION
## Summary
- add a guided three-step checklist to the onboarding modal to clarify the account creation flow
- introduce a copyable call sign display with contextual messaging so first-time players can quickly save their credentials
- update onboarding styles to support the new helper content and feedback states

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db3e0096f08324854d1fe644c623ce