### PR TITLE
Fix mascot sprite fallback when manifest entry missing

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1195,7 +1195,7 @@ function createOptionalSprite(assetPath) {
   if (assetManifest) {
     const source = assetManifest[assetPath];
     if (!source) {
-      return createEmptySprite();
+      return createOptionalSpriteWithoutManifest(assetPath);
     }
 
     const spriteState = createSpriteState(assetPath);


### PR DESCRIPTION
## Summary
- fall back to runtime asset resolution when the sprite manifest lacks an entry so custom mascot PNGs still load on the lobby and message board

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db45b02d8c8324b6580983da0bb5f7