### PR TITLE
Add recovery flow for forgotten call signs

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -2463,6 +2463,101 @@ body.is-scroll-locked {
   justify-content: flex-start;
 }
 
+.onboarding-signin__recovery-toggle {
+  align-self: flex-start;
+  padding: 0;
+  border: none;
+  background: none;
+  color: rgba(142, 222, 255, 0.9);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.onboarding-signin__recovery-toggle:hover,
+.onboarding-signin__recovery-toggle:focus-visible {
+  color: rgba(190, 242, 255, 0.95);
+  text-decoration-thickness: 2px;
+  outline: none;
+}
+
+.onboarding-signin__recovery {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 12px 14px;
+  border-radius: 14px;
+  border: 1px solid rgba(116, 180, 255, 0.28);
+  background: rgba(13, 30, 56, 0.82);
+}
+
+.onboarding-form--recovery {
+  gap: 12px;
+}
+
+.onboarding-field--recovery {
+  margin: 0;
+}
+
+.onboarding-signin__recovery-actions {
+  justify-content: flex-start;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.onboarding-signin__recovery-submit {
+  padding: 8px 18px;
+  font-size: 13px;
+}
+
+.onboarding-signin__recovery-results {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.onboarding-signin__recovery-status {
+  margin: 0;
+}
+
+.onboarding-signin__recovery-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.onboarding-signin__recovery-item {
+  margin: 0;
+}
+
+.onboarding-signin__recovery-option {
+  padding: 6px 14px;
+  border-radius: 999px;
+  border: 1px solid rgba(134, 225, 255, 0.4);
+  background: rgba(134, 225, 255, 0.16);
+  color: #f4f7ff;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.onboarding-signin__recovery-option:hover,
+.onboarding-signin__recovery-option:focus-visible {
+  transform: translateY(-1px);
+  border-color: rgba(180, 240, 255, 0.8);
+  box-shadow: 0 10px 18px rgba(12, 20, 42, 0.45);
+  outline: none;
+}
+
+.onboarding-signin__recovery-option:active {
+  transform: translateY(0);
+}
+
 .onboarding-feedback {
   margin: 0;
   font-size: 13px;


### PR DESCRIPTION
## Summary
- add a stored-account helper to look up call signs by email and reuse sanitized data
- extend the onboarding sign-in panel with a "Forgot call sign?" recovery form and feedback
- adjust styles so the new recovery controls and results fit without overlapping existing content

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc2510a5448324bd36bc94436f2f1d