### PR TITLE
Reuse frame justPressed buffer

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -4984,6 +4984,7 @@ function completeMission(missionId) {
 
 const keys = new Set();
 const justPressed = new Set();
+const frameJustPressed = new Set();
 const emptyJustPressedSet = new Set();
 let currentJustPressed = justPressed;
 
@@ -5271,7 +5272,10 @@ function loop(timestamp) {
 
   accumulatedFrameTime = Math.min(accumulatedFrameTime + frameTime, MAX_ACCUMULATED_TIME);
 
-  const frameJustPressed = new Set(justPressed);
+  frameJustPressed.clear();
+  for (const code of justPressed) {
+    frameJustPressed.add(code);
+  }
   let processedInput = false;
 
   while (accumulatedFrameTime >= FIXED_TIMESTEP) {


### PR DESCRIPTION
## Summary
- define a module-scoped `frameJustPressed` set so it can be reused across frames
- update the animation loop to clear and repopulate the shared set instead of constructing a new one each frame
- keep the existing `currentJustPressed` handoff logic while pointing it at the shared set

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcea963fbc8324b128464af0ea6ac2