### PR TITLE
Cache world instances for offset rendering

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -6247,17 +6247,33 @@ function createLobbyLayoutEditor(options = {}) {
   };
 }
 
+const worldInstanceCache = new WeakMap();
+
 function createWorldInstance(entity, offset) {
   if (!entity || !Number.isFinite(offset) || offset === 0) {
     return entity;
   }
-  const instance = { ...entity };
+
+  let instance = worldInstanceCache.get(entity);
+  if (!instance) {
+    instance = {};
+    worldInstanceCache.set(entity, instance);
+  }
+
+  Object.assign(instance, entity);
+
   if (typeof entity.x === "number") {
     instance.x = entity.x + offset;
+  } else {
+    delete instance.x;
   }
+
   if (typeof entity.promptAnchorX === "number") {
     instance.promptAnchorX = entity.promptAnchorX + offset;
+  } else {
+    delete instance.promptAnchorX;
   }
+
   return instance;
 }
 


### PR DESCRIPTION
## Summary
- add a WeakMap-backed cache for world instances so offset renders reuse a mutable view object
- update `createWorldInstance` to synchronize cached instances and adjust offset-sensitive properties

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dceaa2c104832481ff611278e88fdb