### PR TITLE
Broaden browser compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ This downlevels modern JavaScript features so the game boots cleanly across more
 
 ## Browser compatibility
 
-The Vite build now targets evergreen browsers as far back as Safari 13/Chrome 61 and includes runtime shims for `globalThis` and the `URL` constructor. Run `npm run build` before distributing the beta to ensure the transpiled output and compatibility helpers are included. Older browsers that still lack fundamental Web APIs will gracefully fall back to the lobby's built-in warnings instead of crashing.
+The Vite build now targets ES2015-era evergreen browsers such as Safari 11 and Chrome 61 and includes runtime shims for `globalThis` and the `URL` constructor. Run `npm run build` before distributing the beta to ensure the transpiled output and compatibility helpers are included. Older browsers that still lack fundamental Web APIs will gracefully fall back to the lobby's built-in warnings instead of crashing.
 
 ## Password hashing
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -177,13 +177,16 @@ export default defineConfig({
   base: "./",
   plugins: [publicManifestPlugin()],
   build: {
-    target: ["es2018", "safari13"],
-    cssTarget: ["chrome61", "safari13"],
+    target: ["es2015", "safari11"],
+    cssTarget: ["chrome61", "safari11"],
     modulePreload: { polyfill: true }
+  },
+  esbuild: {
+    target: "es2015"
   },
   optimizeDeps: {
     esbuildOptions: {
-      target: "es2018"
+      target: "es2015"
     }
   }
 });


### PR DESCRIPTION
## Summary
- lower the Vite build target to ES2015/Safari 11 and align dev esbuild settings for older browser support
- document the expanded compatibility guarantees in the README

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dcef94de0c8324b6dd6900b29662e3