### PR TITLE
Add idle controls tooltip for first-session players

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -360,6 +360,85 @@ body.is-scroll-locked {
   z-index: 12;
 }
 
+.movement-hint {
+  position: absolute;
+  left: 0;
+  top: 0;
+  transform: translate(-50%, calc(-100% - 12px));
+  padding: 16px 20px;
+  border-radius: 18px;
+  border: 1px solid rgba(134, 225, 255, 0.32);
+  background: linear-gradient(180deg, rgba(12, 18, 36, 0.96), rgba(6, 12, 26, 0.92));
+  box-shadow: 0 18px 36px rgba(6, 10, 26, 0.55);
+  color: #f5f8ff;
+  display: none;
+  max-width: 280px;
+  width: max-content;
+  min-width: 220px;
+  pointer-events: auto;
+  z-index: 18;
+  backdrop-filter: blur(6px);
+}
+
+.movement-hint.is-visible {
+  display: block;
+}
+
+.movement-hint__title {
+  margin: 0 0 12px;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: rgba(213, 243, 255, 0.76);
+}
+
+.movement-hint__body {
+  margin: 0 0 14px;
+}
+
+.movement-hint__body .instruction-list {
+  padding: 12px 14px;
+  gap: 8px;
+  background: rgba(18, 28, 48, 0.68);
+  border: 1px solid rgba(134, 225, 255, 0.24);
+}
+
+.movement-hint__body .instruction-list__item {
+  justify-content: space-between;
+}
+
+.movement-hint__footer {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.movement-hint__ack {
+  padding: 8px 18px;
+  border-radius: 999px;
+  border: 1px solid rgba(134, 225, 255, 0.48);
+  background: linear-gradient(135deg, rgba(134, 225, 255, 0.2), rgba(188, 146, 255, 0.32));
+  color: #f5f8ff;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  cursor: pointer;
+  box-shadow: 0 10px 24px rgba(12, 18, 40, 0.45);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+}
+
+.movement-hint__ack:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 14px 26px rgba(12, 18, 40, 0.5);
+  opacity: 0.95;
+}
+
+.movement-hint__ack:active {
+  transform: translateY(1px);
+  box-shadow: 0 8px 18px rgba(12, 18, 40, 0.45);
+}
+
 .audio-unlock:hover {
   transform: translateX(-50%) translateY(-2px);
 }


### PR DESCRIPTION
## Summary
- track idle time without movement input and trigger a reusable controls hint for first-session players
- add UI helpers that reuse the HUD instruction list to render a dismissible tooltip near the player
- style the new tooltip so it matches the lobby canvas overlay aesthetics

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de2847d4f083249cafea9a1b579356