### PR TITLE
Add clamp utility to prevent attribute scaling crash

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -108,6 +108,22 @@ function normalizePublicRelativePath(relativePath) {
     .replace(/\\/g, "/");
 }
 
+function clamp(value, min, max) {
+  if (!Number.isFinite(value)) {
+    value = Number.isFinite(min) ? min : 0;
+  }
+
+  if (Number.isFinite(min)) {
+    value = Math.max(min, value);
+  }
+
+  if (Number.isFinite(max)) {
+    value = Math.min(max, value);
+  }
+
+  return value;
+}
+
 function getPublicManifest() {
   if (typeof globalThis === "undefined") {
     return null;


### PR DESCRIPTION
## Summary
- add a shared clamp helper used by attribute scaling and other runtime utilities
- guard against non-finite values so stats updates no longer throw at runtime

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e18cd0b7d08324bb242f42a0856508